### PR TITLE
rdev 0.8.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
     renv,
     rlang,
     usethis,
+    withr,
     yaml,
     markdown,
     miniUI

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rdev
 Title: R Development Tools
-Version: 0.8.1
+Version: 0.8.1.9000
 Authors@R:
     person("John", "Benninghoff", email = "jbenninghoff@mac.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6230-4742"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rdev
 Title: R Development Tools
-Version: 0.8.1.9000
+Version: 0.8.2
 Authors@R:
     person("John", "Benninghoff", email = "jbenninghoff@mac.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6230-4742"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rdev 0.8.2
+
+* Updated `build_rdev_site()` and `build_analysis_site()` to abort if there are missing topics in the [pkgdown reference section](https://pkgdown.r-lib.org/reference/build_reference.html)
+
 # rdev 0.8.1
 
 * Added `new_branch()`: Create a new feature branch, and (optionally) bump the version in DESCRIPTION

--- a/R/build.R
+++ b/R/build.R
@@ -8,6 +8,11 @@
 #' 1. [pkgdown::clean_site()]
 #' 1. [pkgdown::build_site()]
 #'
+#' Both `build_rdev_site()` and [build_analysis_site()] are meant to be used as part of a CI/CD
+#'   workflow, and temporarily set the environment variable `CI == "TRUE"` so that the build will
+#'   fail when non-internal topics are not included on the reference index page per
+#'   [pkgdown::build_reference()].
+#'
 #' @param pkg Path to package. Currently, only `pkg = "."` is supported.
 #' @param ... additional arguments passed to [pkgdown::build_site()] (not implemented)
 #'
@@ -18,7 +23,7 @@ build_rdev_site <- function(pkg = ".", ...) {
   }
   devtools::build_readme()
   pkgdown::clean_site()
-  pkgdown::build_site()
+  withr::with_envvar(c("CI" = "TRUE"), pkgdown::build_site())
 }
 
 #' Convert R Notebook to `html_document`
@@ -76,10 +81,12 @@ to_document <- function(file_path, new_path, overwrite = FALSE) {
 #' `build_analysis_site()` will fail with an error if there are no files in `analysis/*.Rmd`, or if
 #'   `pkgdown/_base.yml` does not exist.
 #'
-#' **Warning:** `build_analysis_site()` is currently considered Experimental. Currently only
-#'   `build_analysis_site(pkg = ".")` is supported.
+#' Both [build_rdev_site()] and `build_analysis_site()` are meant to be used as part of a CI/CD
+#'   workflow, and temporarily set the environment variable `CI == "TRUE"` so that the build will
+#'   fail when non-internal topics are not included on the reference index page per
+#'   [pkgdown::build_reference()].
 #'
-#' @param pkg Path to package.
+#' @param pkg Path to package. Currently, only `pkg = "."` is supported.
 #' @param ... additional arguments passed to [pkgdown::build_site()] (not implemented)
 #'
 #' @export
@@ -128,7 +135,7 @@ build_analysis_site <- function(pkg = ".", ...) {
 
   # run clean_site() and build_site()
   pkgdown::clean_site()
-  pkgdown::build_site()
+  withr::with_envvar(c("CI" = "TRUE"), pkgdown::build_site())
 
   # create _site.yml from _pkgdown.yml in temporary build directory
   desc <- desc::description$new(pkg)

--- a/R/release.R
+++ b/R/release.R
@@ -156,7 +156,6 @@ stage_release <- function(pkg = ".", filename = "NEWS.md", host = NULL) {
   desc::desc_set_version(rel$version, file = pkg)
   gert::git_add("DESCRIPTION")
   gert::git_commit(rel_message)
-  gert::git_push()
 
   if (fs::file_exists("pkgdown/_base.yml")) {
     builder <- "build_analysis_site()"

--- a/README.md
+++ b/README.md
@@ -129,16 +129,16 @@ ci()
 #> * creating vignettes ... OK
 #> * checking for LF line-endings in source and make files and shell scripts
 #> * checking for empty or unneeded directories
-#> * building ‘rdev_0.8.1.tar.gz’
+#> * building ‘rdev_0.8.2.tar.gz’
 #> 
 #> ── R CMD check ─────────────────────────────────────────────────────────────────
-#> * using log directory ‘/private/var/folders/vn/cw5f9gws42v9m8mdsds_zbl00000gp/T/RtmpykRo44/file3a1858f10947/rdev.Rcheck’
+#> * using log directory ‘/private/var/folders/vn/cw5f9gws42v9m8mdsds_zbl00000gp/T/RtmpqxgD3N/file4a0e30f7fb7b/rdev.Rcheck’
 #> * using R version 4.1.2 (2021-11-01)
 #> * using platform: x86_64-apple-darwin19.6.0 (64-bit)
 #> * using session charset: UTF-8
 #> * using option ‘--no-manual’
 #> * checking for file ‘rdev/DESCRIPTION’ ... OK
-#> * this is package ‘rdev’ version ‘0.8.1’
+#> * this is package ‘rdev’ version ‘0.8.2’
 #> * package encoding: UTF-8
 #> * checking package namespace information ... OK
 #> * checking package dependencies ... OK
@@ -194,8 +194,8 @@ ci()
 #> * DONE
 #> 
 #> Status: OK
-#> ── R CMD check results ───────────────────────────────────────── rdev 0.8.1 ────
-#> Duration: 18.6s
+#> ── R CMD check results ───────────────────────────────────────── rdev 0.8.2 ────
+#> Duration: 16.5s
 #> 
 #> 0 errors ✓ | 0 warnings ✓ | 0 notes ✓
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,7 @@
 - [x] Add 'create package' workflow example to README, remove TODO section "Analysis package creation process"
 - [x] Move `_pkgdown.yml` to repository root to make projects discoverable by the [pgkdown](https://pkgdown.r-lib.org) GitHub [query](https://github.com/search?q=filename%3Apkgdown.yml+path%3A%2F&type=Code)
 - [x] Update `README.Rmd` template to dynamically generate list of notebooks in `analysis`
-- [ ] Add check to `stage_release()` to look for missing functions in `_pkgdown.yml` reference section
+- [x] Add check to `stage_release()` to look for missing topics in `_pkgdown.yml` reference section
 - [ ] Update `use_rdev_package()`
 - [x] Automate creation of feature branches, including 'Bump version' using `desc::desc_bump_version("dev")`
 - [ ] Review and merge duplicate Roxygen docs

--- a/docs/404.html
+++ b/docs/404.html
@@ -32,7 +32,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="https://jabenninghoff.github.io/rdev/index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/LICENSE.html
+++ b/docs/LICENSE.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/TODO.html
+++ b/docs/TODO.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 
@@ -108,6 +108,10 @@ GitHub <a href="https://github.com/search?q=filename%3Apkgdown.yml+path%3A%2F&am
 Update <code>README.Rmd</code> template to dynamically generate list of
 notebooks in <code>analysis</code>
 </li>
+<li>
+<input type="checkbox" disabled checked>
+Add check to <code><a href="reference/stage_release.html">stage_release()</a></code> to look for missing topics in
+<code>_pkgdown.yml</code> reference section</li>
 <li>
 <input type="checkbox" disabled>
 Update <code><a href="reference/use_rdev_package.html">use_rdev_package()</a></code>

--- a/docs/articles/analysis-package-layout.html
+++ b/docs/articles/analysis-package-layout.html
@@ -33,7 +33,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 
@@ -204,16 +204,16 @@ integration tests locally:</p>
 <span class="co">#&gt; * creating vignettes ... OK</span>
 <span class="co">#&gt; * checking for LF line-endings in source and make files and shell scripts</span>
 <span class="co">#&gt; * checking for empty or unneeded directories</span>
-<span class="co">#&gt; * building ‘rdev_0.8.1.tar.gz’</span>
+<span class="co">#&gt; * building ‘rdev_0.8.2.tar.gz’</span>
 <span class="co">#&gt; </span>
 <span class="co">#&gt; ── R CMD check ─────────────────────────────────────────────────────────────────</span>
-<span class="co">#&gt; * using log directory ‘/private/var/folders/vn/cw5f9gws42v9m8mdsds_zbl00000gp/T/RtmpykRo44/file3a1858f10947/rdev.Rcheck’</span>
+<span class="co">#&gt; * using log directory ‘/private/var/folders/vn/cw5f9gws42v9m8mdsds_zbl00000gp/T/RtmpqxgD3N/file4a0e30f7fb7b/rdev.Rcheck’</span>
 <span class="co">#&gt; * using R version 4.1.2 (2021-11-01)</span>
 <span class="co">#&gt; * using platform: x86_64-apple-darwin19.6.0 (64-bit)</span>
 <span class="co">#&gt; * using session charset: UTF-8</span>
 <span class="co">#&gt; * using option ‘--no-manual’</span>
 <span class="co">#&gt; * checking for file ‘rdev/DESCRIPTION’ ... OK</span>
-<span class="co">#&gt; * this is package ‘rdev’ version ‘0.8.1’</span>
+<span class="co">#&gt; * this is package ‘rdev’ version ‘0.8.2’</span>
 <span class="co">#&gt; * package encoding: UTF-8</span>
 <span class="co">#&gt; * checking package namespace information ... OK</span>
 <span class="co">#&gt; * checking package dependencies ... OK</span>
@@ -269,8 +269,8 @@ integration tests locally:</p>
 <span class="co">#&gt; * DONE</span>
 <span class="co">#&gt; </span>
 <span class="co">#&gt; Status: OK</span>
-<span class="co">#&gt; ── R CMD check results ───────────────────────────────────────── rdev 0.8.1 ────</span>
-<span class="co">#&gt; Duration: 18.6s</span>
+<span class="co">#&gt; ── R CMD check results ───────────────────────────────────────── rdev 0.8.2 ────</span>
+<span class="co">#&gt; Duration: 16.5s</span>
 <span class="co">#&gt; </span>
 <span class="co">#&gt; 0 errors ✓ | 0 warnings ✓ | 0 notes ✓</span></code></pre></div>
 </div>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 
@@ -57,6 +57,14 @@
       <small>Source: <a href="https://github.com/jabenninghoff/rdev/blob/HEAD/NEWS.md" class="external-link"><code>NEWS.md</code></a></small>
     </div>
 
+    <div class="section level2">
+<h2 class="page-header" data-toc-text="0.8.2" id="rdev-082">rdev 0.8.2<a class="anchor" aria-label="anchor" href="#rdev-082"></a></h2>
+<ul><li>Updated <code><a href="../reference/build_rdev_site.html">build_rdev_site()</a></code> and
+<code><a href="../reference/build_analysis_site.html">build_analysis_site()</a></code> to abort if there are missing topics
+in the <a href="https://pkgdown.r-lib.org/reference/build_reference.html" class="external-link">pkgdown
+reference section</a>
+</li>
+</ul></div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.8.1" id="rdev-081">rdev 0.8.1<a class="anchor" aria-label="anchor" href="#rdev-081"></a></h2>
 <ul><li>Added <code><a href="../reference/new_branch.html">new_branch()</a></code>: Create a new feature branch, and

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,7 +3,7 @@ pkgdown: 2.0.2
 pkgdown_sha: ~
 articles:
   analysis-package-layout: analysis-package-layout.html
-last_built: 2022-01-19T13:29Z
+last_built: 2022-01-20T00:47Z
 urls:
   reference: https://jabenninghoff.github.io/rdev/reference
   article: https://jabenninghoff.github.io/rdev/articles

--- a/docs/reference/build_analysis_site.html
+++ b/docs/reference/build_analysis_site.html
@@ -18,7 +18,7 @@ containing rendered versions of all .Rmd files in analysis/."><!-- mathjax --><s
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 
@@ -71,7 +71,7 @@ containing rendered versions of all .Rmd files in <code>analysis/</code>.</p>
     <div id="arguments">
     <h2>Arguments</h2>
     <dl><dt>pkg</dt>
-<dd><p>Path to package.</p></dd>
+<dd><p>Path to package. Currently, only <code>pkg = "."</code> is supported.</p></dd>
 <dt>...</dt>
 <dd><p>additional arguments passed to <code><a href="https://pkgdown.r-lib.org/reference/build_site.html" class="external-link">pkgdown::build_site()</a></code> (not implemented)</p></dd>
 </dl></div>
@@ -95,8 +95,10 @@ to render files with the look and feel of <code>html_notebook</code></p></li>
 <li><p>Moves the rendered files to <code>docs/</code>: <code>*.html</code>, <code>assets/</code>, <code>rendered/</code>, without overwriting</p></li>
 </ol><p><code>build_analysis_site()</code> will fail with an error if there are no files in <code>analysis/*.Rmd</code>, or if
 <code>pkgdown/_base.yml</code> does not exist.</p>
-<p><strong>Warning:</strong> <code>build_analysis_site()</code> is currently considered Experimental. Currently only
-<code>build_analysis_site(pkg = ".")</code> is supported.</p>
+<p>Both <code><a href="build_rdev_site.html">build_rdev_site()</a></code> and <code>build_analysis_site()</code> are meant to be used as part of a CI/CD
+workflow, and temporarily set the environment variable <code>CI == "TRUE"</code> so that the build will
+fail when non-internal topics are not included on the reference index page per
+<code><a href="https://pkgdown.r-lib.org/reference/build_reference.html" class="external-link">pkgdown::build_reference()</a></code>.</p>
     </div>
 
   </div>

--- a/docs/reference/build_rdev_site.html
+++ b/docs/reference/build_rdev_site.html
@@ -18,7 +18,7 @@ updates README.md and performs a clean build using pkgdown."><!-- mathjax --><sc
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 
@@ -80,7 +80,11 @@ updates <code>README.md</code> and performs a clean build using <code>pkgdown</c
     <p>When run, <code>build_rdev_site()</code> calls:</p><ol><li><p><code><a href="https://devtools.r-lib.org/reference/build_rmd.html" class="external-link">devtools::build_readme()</a></code></p></li>
 <li><p><code><a href="https://pkgdown.r-lib.org/reference/clean_site.html" class="external-link">pkgdown::clean_site()</a></code></p></li>
 <li><p><code><a href="https://pkgdown.r-lib.org/reference/build_site.html" class="external-link">pkgdown::build_site()</a></code></p></li>
-</ol></div>
+</ol><p>Both <code>build_rdev_site()</code> and <code><a href="build_analysis_site.html">build_analysis_site()</a></code> are meant to be used as part of a CI/CD
+workflow, and temporarily set the environment variable <code>CI == "TRUE"</code> so that the build will
+fail when non-internal topics are not included on the reference index page per
+<code><a href="https://pkgdown.r-lib.org/reference/build_reference.html" class="external-link">pkgdown::build_reference()</a></code>.</p>
+    </div>
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">

--- a/docs/reference/check_renv.html
+++ b/docs/reference/check_renv.html
@@ -18,7 +18,7 @@ optionally update()"><!-- mathjax --><script src="https://cdnjs.cloudflare.com/a
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/ci.html
+++ b/docs/reference/ci.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/create_github_repo.html
+++ b/docs/reference/create_github_repo.html
@@ -21,7 +21,7 @@ automatically be opened in RStudio, GitHub Desktop, and the default browser."><!
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/get_release.html
+++ b/docs/reference/get_release.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/lint_all.html
+++ b/docs/reference/lint_all.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/merge_release.html
+++ b/docs/reference/merge_release.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/new_branch.html
+++ b/docs/reference/new_branch.html
@@ -19,7 +19,7 @@ desc::desc_bump_version()."><!-- mathjax --><script src="https://cdnjs.cloudflar
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/rdev-package.html
+++ b/docs/reference/rdev-package.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/sort_file.html
+++ b/docs/reference/sort_file.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/sort_rbuildignore.html
+++ b/docs/reference/sort_rbuildignore.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/stage_release.html
+++ b/docs/reference/stage_release.html
@@ -18,7 +18,7 @@ release using merge_release()."><!-- mathjax --><script src="https://cdnjs.cloud
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/style_all.html
+++ b/docs/reference/style_all.html
@@ -18,7 +18,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/to_document.html
+++ b/docs/reference/to_document.html
@@ -19,7 +19,7 @@ without changing the output type."><!-- mathjax --><script src="https://cdnjs.cl
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/use_analysis_package.html
+++ b/docs/reference/use_analysis_package.html
@@ -18,7 +18,7 @@ to the current package."><!-- mathjax --><script src="https://cdnjs.cloudflare.c
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/use_lintr.html
+++ b/docs/reference/use_lintr.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/use_package_r.html
+++ b/docs/reference/use_package_r.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/use_rdev_package.html
+++ b/docs/reference/use_rdev_package.html
@@ -18,7 +18,7 @@ up a package."><!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/li
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/use_rprofile.html
+++ b/docs/reference/use_rprofile.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/use_todo.html
+++ b/docs/reference/use_todo.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">0.8.2</span>
       </span>
     </div>
 

--- a/man/build_analysis_site.Rd
+++ b/man/build_analysis_site.Rd
@@ -7,7 +7,7 @@
 build_analysis_site(pkg = ".", ...)
 }
 \arguments{
-\item{pkg}{Path to package.}
+\item{pkg}{Path to package. Currently, only \code{pkg = "."} is supported.}
 
 \item{...}{additional arguments passed to \code{\link[pkgdown:build_site]{pkgdown::build_site()}} (not implemented)}
 }
@@ -39,6 +39,8 @@ to render files with the look and feel of \code{html_notebook}
 \code{build_analysis_site()} will fail with an error if there are no files in \verb{analysis/*.Rmd}, or if
 \verb{pkgdown/_base.yml} does not exist.
 
-\strong{Warning:} \code{build_analysis_site()} is currently considered Experimental. Currently only
-\code{build_analysis_site(pkg = ".")} is supported.
+Both \code{\link[=build_rdev_site]{build_rdev_site()}} and \code{build_analysis_site()} are meant to be used as part of a CI/CD
+workflow, and temporarily set the environment variable \code{CI == "TRUE"} so that the build will
+fail when non-internal topics are not included on the reference index page per
+\code{\link[pkgdown:build_reference]{pkgdown::build_reference()}}.
 }

--- a/man/build_rdev_site.Rd
+++ b/man/build_rdev_site.Rd
@@ -22,4 +22,9 @@ When run, \code{build_rdev_site()} calls:
 \item \code{\link[pkgdown:clean_site]{pkgdown::clean_site()}}
 \item \code{\link[pkgdown:build_site]{pkgdown::build_site()}}
 }
+
+Both \code{build_rdev_site()} and \code{\link[=build_analysis_site]{build_analysis_site()}} are meant to be used as part of a CI/CD
+workflow, and temporarily set the environment variable \code{CI == "TRUE"} so that the build will
+fail when non-internal topics are not included on the reference index page per
+\code{\link[pkgdown:build_reference]{pkgdown::build_reference()}}.
 }


### PR DESCRIPTION
* Updated `build_rdev_site()` and `build_analysis_site()` to abort if there are missing topics in the [pkgdown reference section](https://pkgdown.r-lib.org/reference/build_reference.html)