### PR TITLE
rdev 1.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rdev
 Title: R Development Tools
-Version: 1.0.1
+Version: 1.0.1.9000
 Authors@R:
     person("John", "Benninghoff", email = "jbenninghoff@mac.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6230-4742"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rdev
 Title: R Development Tools
-Version: 1.0.1.9000
+Version: 1.1.0
 Authors@R:
     person("John", "Benninghoff", email = "jbenninghoff@mac.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6230-4742"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# rdev 1.1.0
+
+* Added additional automation to `ci()`:
+  * `style_all()` now runs automatically if there are no uncommitted changes
+  * `lint_all()` now runs by default and opens RStudio markers pane if any lints are found
+
 # rdev 1.0.1
 
 * Minor updates to analysis README.Rmd template

--- a/README.md
+++ b/README.md
@@ -118,6 +118,55 @@ locally:
 
 ``` r
 ci()
+#> style_all()
+#> Styling  38  files:
+#>  .Rprofile                                               ✓ 
+#>  README.Rmd                                              ✓ 
+#>  inst/rmarkdown/templates/analysis/skeleton/skeleton.Rmd ✓ 
+#>  inst/templates/package.R                                ✓ 
+#>  inst/templates/README-analysis.Rmd                      ✓ 
+#>  inst/templates/README-rdev.Rmd                          ✓ 
+#>  inst/templates/spelling.R                               ✓ 
+#>  R/build.R                                               ✓ 
+#>  R/ci.R                                                  ✓ 
+#>  R/helpers.R                                             ✓ 
+#>  R/package.R                                             ✓ 
+#>  R/release.R                                             ✓ 
+#>  R/setup.R                                               ✓ 
+#>  R/to_document.R                                         ✓ 
+#>  R/utils.R                                               ✓ 
+#>  tests/spelling.R                                        ✓ 
+#>  tests/testthat.R                                        ✓ 
+#>  tests/manual/setup.Rmd                                  ✓ 
+#>  tests/testthat/test-build.R                             ✓ 
+#>  tests/testthat/test-ci.R                                ✓ 
+#>  tests/testthat/test-helpers.R                           ✓ 
+#>  tests/testthat/test-release.R                           ✓ 
+#>  tests/testthat/test-setup.R                             ✓ 
+#>  tests/testthat/test-to_document.R                       ✓ 
+#>  tests/testthat/test-utils.R                             ✓ 
+#>  tests/testthat/test-ci/testcode_1.R                     ✓ 
+#>  tests/testthat/test-ci/testcode_2.R                     ✓ 
+#>  tests/testthat/test-ci/testcode.Rmd                     ✓ 
+#>  tests/testthat/test-to_document/document.Rmd            ✓ 
+#>  tests/testthat/test-to_document/extra-spaces.Rmd        ✓ 
+#>  tests/testthat/test-to_document/minimal-document.Rmd    ✓ 
+#>  tests/testthat/test-to_document/minimal.Rmd             ✓ 
+#>  tests/testthat/test-to_document/multiple.Rmd            ✓ 
+#>  tests/testthat/test-to_document/no-front-matter.Rmd     ✓ 
+#>  tests/testthat/test-to_document/no-yaml.Rmd             ✓ 
+#>  tests/testthat/test-to_document/valid.Rmd               ✓ 
+#>  tests/testthat/test-to_document/with-code.Rmd           ✓ 
+#>  vignettes/analysis-package-layout.Rmd                   ✓ 
+#> ───────────────────────────────────────────────────────
+#> Status   Count   Legend 
+#> ✓    38  File unchanged.
+#> ℹ    0   File changed.
+#> x    0   Styling threw an error.
+#> ───────────────────────────────────────────────────────
+#> 
+#> lint_all()
+#> 
 #> devtools::document()
 #> ℹ Updating rdev documentation
 #> ℹ Loading rdev
@@ -133,16 +182,16 @@ ci()
 #> * creating vignettes ... OK
 #> * checking for LF line-endings in source and make files and shell scripts
 #> * checking for empty or unneeded directories
-#> * building ‘rdev_1.0.1.tar.gz’
+#> * building ‘rdev_1.1.0.tar.gz’
 #> 
 #> ── R CMD check ─────────────────────────────────────────────────────────────────
-#> * using log directory ‘/private/var/folders/vn/cw5f9gws42v9m8mdsds_zbl00000gp/T/Rtmpjl7ago/file840a70250426/rdev.Rcheck’
+#> * using log directory ‘/private/var/folders/vn/cw5f9gws42v9m8mdsds_zbl00000gp/T/RtmpFvv9iW/file47f86e712e94/rdev.Rcheck’
 #> * using R version 4.1.2 (2021-11-01)
 #> * using platform: x86_64-apple-darwin19.6.0 (64-bit)
 #> * using session charset: UTF-8
 #> * using option ‘--no-manual’
 #> * checking for file ‘rdev/DESCRIPTION’ ... OK
-#> * this is package ‘rdev’ version ‘1.0.1’
+#> * this is package ‘rdev’ version ‘1.1.0’
 #> * package encoding: UTF-8
 #> * checking package namespace information ... OK
 #> * checking package dependencies ... OK
@@ -197,9 +246,10 @@ ci()
 #>  NONE
 #> * checking re-building of vignette outputs ... OK
 #> * DONE
+#> 
 #> Status: OK
-#> ── R CMD check results ───────────────────────────────────────── rdev 1.0.1 ────
-#> Duration: 26.4s
+#> ── R CMD check results ───────────────────────────────────────── rdev 1.1.0 ────
+#> Duration: 25.9s
 #> 
 #> 0 errors ✓ | 0 warnings ✓ | 0 notes ✓
 ```

--- a/docs/404.html
+++ b/docs/404.html
@@ -32,7 +32,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="https://jabenninghoff.github.io/rdev/index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/LICENSE.html
+++ b/docs/LICENSE.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/TODO.html
+++ b/docs/TODO.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/articles/analysis-package-layout.html
+++ b/docs/articles/analysis-package-layout.html
@@ -33,7 +33,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 
@@ -193,6 +193,55 @@ a feature branch, and create a new release branch if on the default.</p>
 integration tests locally:</p>
 <div class="sourceCode" id="cb4"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="reference/ci.html">ci</a></span><span class="op">(</span><span class="op">)</span>
+<span class="co">#&gt; style_all()</span>
+<span class="co">#&gt; Styling  38  files:</span>
+<span class="co">#&gt;  .Rprofile                                               ✓ </span>
+<span class="co">#&gt;  README.Rmd                                              ✓ </span>
+<span class="co">#&gt;  inst/rmarkdown/templates/analysis/skeleton/skeleton.Rmd ✓ </span>
+<span class="co">#&gt;  inst/templates/package.R                                ✓ </span>
+<span class="co">#&gt;  inst/templates/README-analysis.Rmd                      ✓ </span>
+<span class="co">#&gt;  inst/templates/README-rdev.Rmd                          ✓ </span>
+<span class="co">#&gt;  inst/templates/spelling.R                               ✓ </span>
+<span class="co">#&gt;  R/build.R                                               ✓ </span>
+<span class="co">#&gt;  R/ci.R                                                  ✓ </span>
+<span class="co">#&gt;  R/helpers.R                                             ✓ </span>
+<span class="co">#&gt;  R/package.R                                             ✓ </span>
+<span class="co">#&gt;  R/release.R                                             ✓ </span>
+<span class="co">#&gt;  R/setup.R                                               ✓ </span>
+<span class="co">#&gt;  R/to_document.R                                         ✓ </span>
+<span class="co">#&gt;  R/utils.R                                               ✓ </span>
+<span class="co">#&gt;  tests/spelling.R                                        ✓ </span>
+<span class="co">#&gt;  tests/testthat.R                                        ✓ </span>
+<span class="co">#&gt;  tests/manual/setup.Rmd                                  ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-build.R                             ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-ci.R                                ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-helpers.R                           ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-release.R                           ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-setup.R                             ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-to_document.R                       ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-utils.R                             ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-ci/testcode_1.R                     ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-ci/testcode_2.R                     ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-ci/testcode.Rmd                     ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-to_document/document.Rmd            ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-to_document/extra-spaces.Rmd        ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-to_document/minimal-document.Rmd    ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-to_document/minimal.Rmd             ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-to_document/multiple.Rmd            ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-to_document/no-front-matter.Rmd     ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-to_document/no-yaml.Rmd             ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-to_document/valid.Rmd               ✓ </span>
+<span class="co">#&gt;  tests/testthat/test-to_document/with-code.Rmd           ✓ </span>
+<span class="co">#&gt;  vignettes/analysis-package-layout.Rmd                   ✓ </span>
+<span class="co">#&gt; ───────────────────────────────────────────────────────</span>
+<span class="co">#&gt; Status   Count   Legend </span>
+<span class="co">#&gt; ✓    38  File unchanged.</span>
+<span class="co">#&gt; ℹ    0   File changed.</span>
+<span class="co">#&gt; x    0   Styling threw an error.</span>
+<span class="co">#&gt; ───────────────────────────────────────────────────────</span>
+<span class="co">#&gt; </span>
+<span class="co">#&gt; lint_all()</span>
+<span class="co">#&gt; </span>
 <span class="co">#&gt; devtools::document()</span>
 <span class="co">#&gt; ℹ Updating rdev documentation</span>
 <span class="co">#&gt; ℹ Loading rdev</span>
@@ -208,16 +257,16 @@ integration tests locally:</p>
 <span class="co">#&gt; * creating vignettes ... OK</span>
 <span class="co">#&gt; * checking for LF line-endings in source and make files and shell scripts</span>
 <span class="co">#&gt; * checking for empty or unneeded directories</span>
-<span class="co">#&gt; * building ‘rdev_1.0.1.tar.gz’</span>
+<span class="co">#&gt; * building ‘rdev_1.1.0.tar.gz’</span>
 <span class="co">#&gt; </span>
 <span class="co">#&gt; ── R CMD check ─────────────────────────────────────────────────────────────────</span>
-<span class="co">#&gt; * using log directory ‘/private/var/folders/vn/cw5f9gws42v9m8mdsds_zbl00000gp/T/Rtmpjl7ago/file840a70250426/rdev.Rcheck’</span>
+<span class="co">#&gt; * using log directory ‘/private/var/folders/vn/cw5f9gws42v9m8mdsds_zbl00000gp/T/RtmpFvv9iW/file47f86e712e94/rdev.Rcheck’</span>
 <span class="co">#&gt; * using R version 4.1.2 (2021-11-01)</span>
 <span class="co">#&gt; * using platform: x86_64-apple-darwin19.6.0 (64-bit)</span>
 <span class="co">#&gt; * using session charset: UTF-8</span>
 <span class="co">#&gt; * using option ‘--no-manual’</span>
 <span class="co">#&gt; * checking for file ‘rdev/DESCRIPTION’ ... OK</span>
-<span class="co">#&gt; * this is package ‘rdev’ version ‘1.0.1’</span>
+<span class="co">#&gt; * this is package ‘rdev’ version ‘1.1.0’</span>
 <span class="co">#&gt; * package encoding: UTF-8</span>
 <span class="co">#&gt; * checking package namespace information ... OK</span>
 <span class="co">#&gt; * checking package dependencies ... OK</span>
@@ -272,9 +321,10 @@ integration tests locally:</p>
 <span class="co">#&gt;  NONE</span>
 <span class="co">#&gt; * checking re-building of vignette outputs ... OK</span>
 <span class="co">#&gt; * DONE</span>
+<span class="co">#&gt; </span>
 <span class="co">#&gt; Status: OK</span>
-<span class="co">#&gt; ── R CMD check results ───────────────────────────────────────── rdev 1.0.1 ────</span>
-<span class="co">#&gt; Duration: 26.4s</span>
+<span class="co">#&gt; ── R CMD check results ───────────────────────────────────────── rdev 1.1.0 ────</span>
+<span class="co">#&gt; Duration: 25.9s</span>
 <span class="co">#&gt; </span>
 <span class="co">#&gt; 0 errors ✓ | 0 warnings ✓ | 0 notes ✓</span></code></pre></div>
 </div>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 
@@ -57,6 +57,17 @@
       <small>Source: <a href="https://github.com/jabenninghoff/rdev/blob/HEAD/NEWS.md" class="external-link"><code>NEWS.md</code></a></small>
     </div>
 
+    <div class="section level2">
+<h2 class="page-header" data-toc-text="1.1.0" id="rdev-110">rdev 1.1.0<a class="anchor" aria-label="anchor" href="#rdev-110"></a></h2>
+<ul><li>Added additional automation to <code><a href="../reference/ci.html">ci()</a></code>:
+<ul><li>
+<code><a href="../reference/style_all.html">style_all()</a></code> now runs automatically if there are no
+uncommitted changes</li>
+<li>
+<code><a href="../reference/lint_all.html">lint_all()</a></code> now runs by default and opens RStudio
+markers pane if any lints are found</li>
+</ul></li>
+</ul></div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="1.0.1" id="rdev-101">rdev 1.0.1<a class="anchor" aria-label="anchor" href="#rdev-101"></a></h2>
 <ul><li>Minor updates to analysis README.Rmd template</li>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,7 +3,7 @@ pkgdown: 2.0.2
 pkgdown_sha: ~
 articles:
   analysis-package-layout: analysis-package-layout.html
-last_built: 2022-02-07T01:18Z
+last_built: 2022-02-13T16:58Z
 urls:
   reference: https://jabenninghoff.github.io/rdev/reference
   article: https://jabenninghoff.github.io/rdev/articles

--- a/docs/reference/build_analysis_site.html
+++ b/docs/reference/build_analysis_site.html
@@ -18,7 +18,7 @@ containing rendered versions of all .Rmd files in analysis/."><!-- mathjax --><s
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/build_rdev_site.html
+++ b/docs/reference/build_rdev_site.html
@@ -18,7 +18,7 @@ updates README.md and performs a clean build using pkgdown."><!-- mathjax --><sc
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/check_renv.html
+++ b/docs/reference/check_renv.html
@@ -18,7 +18,7 @@ optionally update()"><!-- mathjax --><script src="https://cdnjs.cloudflare.com/a
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/ci.html
+++ b/docs/reference/ci.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 
@@ -63,13 +63,13 @@
     </div>
 
     <div id="ref-usage">
-    <div class="sourceCode"><pre class="sourceCode r"><code><span class="fu">ci</span><span class="op">(</span>styler <span class="op">=</span> <span class="cn">FALSE</span>, lintr <span class="op">=</span> <span class="cn">FALSE</span>, document <span class="op">=</span> <span class="cn">TRUE</span>, rcmdcheck <span class="op">=</span> <span class="cn">TRUE</span><span class="op">)</span></code></pre></div>
+    <div class="sourceCode"><pre class="sourceCode r"><code><span class="fu">ci</span><span class="op">(</span>styler <span class="op">=</span> <span class="cn">NULL</span>, lintr <span class="op">=</span> <span class="cn">TRUE</span>, document <span class="op">=</span> <span class="cn">TRUE</span>, rcmdcheck <span class="op">=</span> <span class="cn">TRUE</span><span class="op">)</span></code></pre></div>
     </div>
 
     <div id="arguments">
     <h2>Arguments</h2>
     <dl><dt>styler</dt>
-<dd><p>style all files using <code><a href="style_all.html">style_all()</a></code></p></dd>
+<dd><p>style all files using <code><a href="style_all.html">style_all()</a></code>, see details</p></dd>
 <dt>lintr</dt>
 <dd><p>lint all files using <code><a href="lint_all.html">lint_all()</a></code></p></dd>
 <dt>document</dt>
@@ -78,13 +78,19 @@
 <dd><p>run <code>R CMD check</code> using:
 <code><a href="http://r-lib.github.io/rcmdcheck/reference/rcmdcheck.html" class="external-link">rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning")</a></code></p></dd>
 </dl></div>
+    <div id="details">
+    <h2>Details</h2>
+    <p>If <code>styler</code> is set to <code>NULL</code> (the default), <code><a href="style_all.html">style_all()</a></code> will be run only if there are no
+uncommitted changes to git. Setting the value to <code>TRUE</code> or <code>FALSE</code> overrides this check.</p>
+<p>If <code><a href="lint_all.html">lint_all()</a></code> finds any lints, <code>ci()</code> will stop and open the RStudio markers pane.</p>
+    </div>
 
     <div id="ref-examples">
     <h2>Examples</h2>
     <div class="sourceCode"><pre class="sourceCode r"><code><span class="r-in"><span class="kw">if</span> <span class="op">(</span><span class="cn">FALSE</span><span class="op">)</span> <span class="op">{</span></span>
 <span class="r-in"><span class="fu">ci</span><span class="op">(</span><span class="op">)</span></span>
 <span class="r-in"><span class="fu">ci</span><span class="op">(</span>styler <span class="op">=</span> <span class="cn">TRUE</span><span class="op">)</span></span>
-<span class="r-in"><span class="fu">ci</span><span class="op">(</span>styler <span class="op">=</span> <span class="cn">TRUE</span>, lintr <span class="op">=</span> <span class="cn">TRUE</span>, rcmdcheck <span class="op">=</span> <span class="cn">FALSE</span><span class="op">)</span></span>
+<span class="r-in"><span class="fu">ci</span><span class="op">(</span>styler <span class="op">=</span> <span class="cn">FALSE</span>, rcmdcheck <span class="op">=</span> <span class="cn">FALSE</span><span class="op">)</span></span>
 <span class="r-in"><span class="op">}</span></span>
 </code></pre></div>
     </div>

--- a/docs/reference/create_github_repo.html
+++ b/docs/reference/create_github_repo.html
@@ -21,7 +21,7 @@ automatically be opened in RStudio, GitHub Desktop, and the default browser."><!
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/get_release.html
+++ b/docs/reference/get_release.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/lint_all.html
+++ b/docs/reference/lint_all.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/local_temppkg.html
+++ b/docs/reference/local_temppkg.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/merge_release.html
+++ b/docs/reference/merge_release.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/new_branch.html
+++ b/docs/reference/new_branch.html
@@ -19,7 +19,7 @@ desc::desc_bump_version()."><!-- mathjax --><script src="https://cdnjs.cloudflar
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/rdev-package.html
+++ b/docs/reference/rdev-package.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/rmd_metadata.html
+++ b/docs/reference/rmd_metadata.html
@@ -19,7 +19,7 @@ and construct a URL to the notebook's location on GitHub pages."><!-- mathjax --
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/sort_file.html
+++ b/docs/reference/sort_file.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/sort_rbuildignore.html
+++ b/docs/reference/sort_rbuildignore.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/stage_release.html
+++ b/docs/reference/stage_release.html
@@ -18,7 +18,7 @@ release using merge_release()."><!-- mathjax --><script src="https://cdnjs.cloud
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/style_all.html
+++ b/docs/reference/style_all.html
@@ -18,7 +18,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/to_document.html
+++ b/docs/reference/to_document.html
@@ -18,7 +18,7 @@ html_notebook to html_document, removing all other output types."><!-- mathjax -
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/use_analysis_package.html
+++ b/docs/reference/use_analysis_package.html
@@ -18,7 +18,7 @@ to the current package."><!-- mathjax --><script src="https://cdnjs.cloudflare.c
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/use_codecov.html
+++ b/docs/reference/use_codecov.html
@@ -18,7 +18,7 @@ DT package for covr::report(), and rdev GitHub action test-coverage.yaml.'><!-- 
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/use_lintr.html
+++ b/docs/reference/use_lintr.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/use_package_r.html
+++ b/docs/reference/use_package_r.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/use_rdev_package.html
+++ b/docs/reference/use_rdev_package.html
@@ -18,7 +18,7 @@ up a package."><!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/li
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/use_rprofile.html
+++ b/docs/reference/use_rprofile.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/use_spelling.html
+++ b/docs/reference/use_spelling.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/docs/reference/use_todo.html
+++ b/docs/reference/use_todo.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0</span>
       </span>
     </div>
 

--- a/man/ci.Rd
+++ b/man/ci.Rd
@@ -4,10 +4,10 @@
 \alias{ci}
 \title{Local CI}
 \usage{
-ci(styler = FALSE, lintr = FALSE, document = TRUE, rcmdcheck = TRUE)
+ci(styler = NULL, lintr = TRUE, document = TRUE, rcmdcheck = TRUE)
 }
 \arguments{
-\item{styler}{style all files using \code{\link[=style_all]{style_all()}}}
+\item{styler}{style all files using \code{\link[=style_all]{style_all()}}, see details}
 
 \item{lintr}{lint all files using \code{\link[=lint_all]{lint_all()}}}
 
@@ -19,10 +19,16 @@ ci(styler = FALSE, lintr = FALSE, document = TRUE, rcmdcheck = TRUE)
 \description{
 Run continuous integration tests locally.
 }
+\details{
+If \code{styler} is set to \code{NULL} (the default), \code{\link[=style_all]{style_all()}} will be run only if there are no
+uncommitted changes to git. Setting the value to \code{TRUE} or \code{FALSE} overrides this check.
+
+If \code{\link[=lint_all]{lint_all()}} finds any lints, \code{ci()} will stop and open the RStudio markers pane.
+}
 \examples{
 \dontrun{
 ci()
 ci(styler = TRUE)
-ci(styler = TRUE, lintr = TRUE, rcmdcheck = FALSE)
+ci(styler = FALSE, rcmdcheck = FALSE)
 }
 }

--- a/renv.lock
+++ b/renv.lock
@@ -1110,10 +1110,10 @@
     },
     "systemfonts": {
       "Package": "systemfonts",
-      "Version": "1.0.3",
+      "Version": "1.0.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "5be9fcf8ef6763e8cb13ab009e273a1d",
+      "Hash": "90b28393209827327de889f49935140a",
       "Requirements": [
         "cpp11"
       ]


### PR DESCRIPTION
* Added additional automation to `ci()`:
  * `style_all()` now runs automatically if there are no uncommitted changes
  * `lint_all()` now runs by default and opens RStudio markers pane if any lints are found