### PR TITLE
rdev 1.3.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rdev
 Title: R Development Tools
-Version: 1.3.2
+Version: 1.3.2.9000
 Authors@R:
     person("John", "Benninghoff", email = "jbenninghoff@mac.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6230-4742"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rdev
 Title: R Development Tools
-Version: 1.3.2.9000
+Version: 1.3.3
 Authors@R:
     person("John", "Benninghoff", email = "jbenninghoff@mac.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6230-4742"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rdev 1.3.3
+
+* Fixed `ci()` and `stage_release()` to correctly use `gert::git_stage()` to determine if uncommitted changes exist (instead of `gert::git_diff_patch()`)
+
 # rdev 1.3.2
 
 * Fixed `update_wordlist_notebooks()`: removed duplicate words

--- a/R/ci.R
+++ b/R/ci.R
@@ -85,7 +85,7 @@ lint_all <- function(path = ".", ...) {
 #' @export
 ci <- function(styler = NULL, lintr = TRUE, document = TRUE, rcmdcheck = TRUE) {
   if (is.null(styler)) {
-    styler <- length(gert::git_diff_patch()) == 0
+    styler <- nrow(gert::git_status()) == 0
   }
 
   if (styler) {

--- a/R/release.R
+++ b/R/release.R
@@ -100,7 +100,7 @@ get_release <- function(pkg = ".", filename = "NEWS.md") {
 #' 1. Extracts release version and release notes from `NEWS.md` using [get_release()]
 #' 1. Validates version conforms to rdev conventions (#.#.#) and release notes aren't empty
 #' 1. Verifies that version tag doesn't already exist using [gert::git_tag_list()]
-#' 1. Checks for uncommitted changes and stops if any exist using [gert::git_diff_patch()]
+#' 1. Checks for uncommitted changes and stops if any exist using [gert::git_status()]
 #' 1. Creates a new branch if on the default branch ([gert::git_branch()] `==`
 #'   [usethis::git_default_branch()]) using [gert::git_branch_create()]
 #' 1. Updates `Version` in `DESCRIPTION` with [desc::desc_set_version()], commits and push to git
@@ -138,7 +138,7 @@ stage_release <- function(pkg = ".", filename = "NEWS.md", host = getOption("rde
     stop("release tag '", rel$version, "' already exists!")
   }
 
-  if (length(gert::git_diff_patch()) != 0) {
+  if (nrow(gert::git_status()) != 0) {
     stop("uncommitted changes present, aborting.")
   }
 
@@ -167,7 +167,7 @@ stage_release <- function(pkg = ".", filename = "NEWS.md", host = getOption("rde
     }
   }
   # commit builder changes if there are any
-  if (length(gert::git_diff_patch()) != 0) {
+  if (nrow(gert::git_status()) != 0) {
     gert::git_add(".")
     gert::git_commit(paste0(builder, " for release ", rel$version))
   }

--- a/README.md
+++ b/README.md
@@ -177,16 +177,16 @@ ci()
 #> * creating vignettes ... OK
 #> * checking for LF line-endings in source and make files and shell scripts
 #> * checking for empty or unneeded directories
-#> * building ‘rdev_1.3.2.tar.gz’
+#> * building ‘rdev_1.3.3.tar.gz’
 #> 
 #> ── R CMD check ─────────────────────────────────────────────────────────────────
-#> * using log directory ‘/private/var/folders/vn/cw5f9gws42v9m8mdsds_zbl00000gp/T/RtmpUCO5Pz/filee88214aa95a7/rdev.Rcheck’
+#> * using log directory ‘/private/var/folders/vn/cw5f9gws42v9m8mdsds_zbl00000gp/T/RtmpT5WxMg/file9542257cabe/rdev.Rcheck’
 #> * using R version 4.1.3 (2022-03-10)
 #> * using platform: x86_64-apple-darwin19.6.0 (64-bit)
 #> * using session charset: UTF-8
 #> * using option ‘--no-manual’
 #> * checking for file ‘rdev/DESCRIPTION’ ... OK
-#> * this is package ‘rdev’ version ‘1.3.2’
+#> * this is package ‘rdev’ version ‘1.3.3’
 #> * package encoding: UTF-8
 #> * checking package namespace information ... OK
 #> * checking package dependencies ... OK
@@ -244,8 +244,8 @@ ci()
 #> * DONE
 #> 
 #> Status: OK
-#> ── R CMD check results ───────────────────────────────────────── rdev 1.3.2 ────
-#> Duration: 34.1s
+#> ── R CMD check results ───────────────────────────────────────── rdev 1.3.3 ────
+#> Duration: 34.2s
 #> 
 #> 0 errors ✓ | 0 warnings ✓ | 0 notes ✓
 ```

--- a/docs/404.html
+++ b/docs/404.html
@@ -32,7 +32,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="https://jabenninghoff.github.io/rdev/index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/LICENSE.html
+++ b/docs/LICENSE.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/TODO.html
+++ b/docs/TODO.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/articles/analysis-package-layout.html
+++ b/docs/articles/analysis-package-layout.html
@@ -33,7 +33,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 
@@ -255,16 +255,16 @@ integration tests locally:</p>
 <span class="co">#&gt; * creating vignettes ... OK</span>
 <span class="co">#&gt; * checking for LF line-endings in source and make files and shell scripts</span>
 <span class="co">#&gt; * checking for empty or unneeded directories</span>
-<span class="co">#&gt; * building ‘rdev_1.3.2.tar.gz’</span>
+<span class="co">#&gt; * building ‘rdev_1.3.3.tar.gz’</span>
 <span class="co">#&gt; </span>
 <span class="co">#&gt; ── R CMD check ─────────────────────────────────────────────────────────────────</span>
-<span class="co">#&gt; * using log directory ‘/private/var/folders/vn/cw5f9gws42v9m8mdsds_zbl00000gp/T/RtmpUCO5Pz/filee88214aa95a7/rdev.Rcheck’</span>
+<span class="co">#&gt; * using log directory ‘/private/var/folders/vn/cw5f9gws42v9m8mdsds_zbl00000gp/T/RtmpT5WxMg/file9542257cabe/rdev.Rcheck’</span>
 <span class="co">#&gt; * using R version 4.1.3 (2022-03-10)</span>
 <span class="co">#&gt; * using platform: x86_64-apple-darwin19.6.0 (64-bit)</span>
 <span class="co">#&gt; * using session charset: UTF-8</span>
 <span class="co">#&gt; * using option ‘--no-manual’</span>
 <span class="co">#&gt; * checking for file ‘rdev/DESCRIPTION’ ... OK</span>
-<span class="co">#&gt; * this is package ‘rdev’ version ‘1.3.2’</span>
+<span class="co">#&gt; * this is package ‘rdev’ version ‘1.3.3’</span>
 <span class="co">#&gt; * package encoding: UTF-8</span>
 <span class="co">#&gt; * checking package namespace information ... OK</span>
 <span class="co">#&gt; * checking package dependencies ... OK</span>
@@ -322,8 +322,8 @@ integration tests locally:</p>
 <span class="co">#&gt; * DONE</span>
 <span class="co">#&gt; </span>
 <span class="co">#&gt; Status: OK</span>
-<span class="co">#&gt; ── R CMD check results ───────────────────────────────────────── rdev 1.3.2 ────</span>
-<span class="co">#&gt; Duration: 34.1s</span>
+<span class="co">#&gt; ── R CMD check results ───────────────────────────────────────── rdev 1.3.3 ────</span>
+<span class="co">#&gt; Duration: 34.2s</span>
 <span class="co">#&gt; </span>
 <span class="co">#&gt; 0 errors ✓ | 0 warnings ✓ | 0 notes ✓</span></code></pre></div>
 </div>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 
@@ -57,6 +57,12 @@
       <small>Source: <a href="https://github.com/jabenninghoff/rdev/blob/HEAD/NEWS.md" class="external-link"><code>NEWS.md</code></a></small>
     </div>
 
+    <div class="section level2">
+<h2 class="page-header" data-toc-text="1.3.3" id="rdev-133">rdev 1.3.3<a class="anchor" aria-label="anchor" href="#rdev-133"></a></h2>
+<ul><li>Fixed <code><a href="../reference/ci.html">ci()</a></code> and <code><a href="../reference/stage_release.html">stage_release()</a></code> to
+correctly use <code>gert::git_stage()</code> to determine if uncommitted
+changes exist (instead of <code><a href="https://docs.ropensci.org/gert/reference/git_diff.html" class="external-link">gert::git_diff_patch()</a></code>)</li>
+</ul></div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="1.3.2" id="rdev-132">rdev 1.3.2<a class="anchor" aria-label="anchor" href="#rdev-132"></a></h2>
 <ul><li><p>Fixed <code><a href="../reference/update_wordlist_notebooks.html">update_wordlist_notebooks()</a></code>: removed duplicate

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,9 +1,9 @@
-pandoc: 2.17.1.1
+pandoc: '2.18'
 pkgdown: 2.0.2
 pkgdown_sha: ~
 articles:
   analysis-package-layout: analysis-package-layout.html
-last_built: 2022-04-03T23:38Z
+last_built: 2022-04-05T02:58Z
 urls:
   reference: https://jabenninghoff.github.io/rdev/reference
   article: https://jabenninghoff.github.io/rdev/articles

--- a/docs/reference/build_analysis_site.html
+++ b/docs/reference/build_analysis_site.html
@@ -18,7 +18,7 @@ containing rendered versions of all .Rmd files in analysis/."><!-- mathjax --><s
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/build_rdev_site.html
+++ b/docs/reference/build_rdev_site.html
@@ -18,7 +18,7 @@ updates README.md and performs a clean build using pkgdown."><!-- mathjax --><sc
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/check_renv.html
+++ b/docs/reference/check_renv.html
@@ -18,7 +18,7 @@ optionally update()"><!-- mathjax --><script src="https://cdnjs.cloudflare.com/a
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/ci.html
+++ b/docs/reference/ci.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/create_github_repo.html
+++ b/docs/reference/create_github_repo.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/get_license.html
+++ b/docs/reference/get_license.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/get_release.html
+++ b/docs/reference/get_release.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/lint_all.html
+++ b/docs/reference/lint_all.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/local_temppkg.html
+++ b/docs/reference/local_temppkg.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/merge_release.html
+++ b/docs/reference/merge_release.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/new_branch.html
+++ b/docs/reference/new_branch.html
@@ -19,7 +19,7 @@ desc::desc_bump_version()."><!-- mathjax --><script src="https://cdnjs.cloudflar
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/rdev-package.html
+++ b/docs/reference/rdev-package.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/rmd_metadata.html
+++ b/docs/reference/rmd_metadata.html
@@ -19,7 +19,7 @@ and construct a URL to the notebook's location on GitHub pages."><!-- mathjax --
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/sort_file.html
+++ b/docs/reference/sort_file.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/sort_rbuildignore.html
+++ b/docs/reference/sort_rbuildignore.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/spell_check_notebooks.html
+++ b/docs/reference/spell_check_notebooks.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/stage_release.html
+++ b/docs/reference/stage_release.html
@@ -18,7 +18,7 @@ release using merge_release()."><!-- mathjax --><script src="https://cdnjs.cloud
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 
@@ -92,7 +92,7 @@ acceptable.</p></dd>
     <p>When run, <code>stage_release()</code>:</p><ol><li><p>Extracts release version and release notes from <code>NEWS.md</code> using <code><a href="get_release.html">get_release()</a></code></p></li>
 <li><p>Validates version conforms to rdev conventions (#.#.#) and release notes aren't empty</p></li>
 <li><p>Verifies that version tag doesn't already exist using <code><a href="https://docs.ropensci.org/gert/reference/git_tag.html" class="external-link">gert::git_tag_list()</a></code></p></li>
-<li><p>Checks for uncommitted changes and stops if any exist using <code><a href="https://docs.ropensci.org/gert/reference/git_diff.html" class="external-link">gert::git_diff_patch()</a></code></p></li>
+<li><p>Checks for uncommitted changes and stops if any exist using <code><a href="https://docs.ropensci.org/gert/reference/git_commit.html" class="external-link">gert::git_status()</a></code></p></li>
 <li><p>Creates a new branch if on the default branch (<code><a href="https://docs.ropensci.org/gert/reference/git_branch.html" class="external-link">gert::git_branch()</a></code> <code>==</code>
 <code><a href="https://usethis.r-lib.org/reference/git-default-branch.html" class="external-link">usethis::git_default_branch()</a></code>) using <code><a href="https://docs.ropensci.org/gert/reference/git_branch.html" class="external-link">gert::git_branch_create()</a></code></p></li>
 <li><p>Updates <code>Version</code> in <code>DESCRIPTION</code> with <code><a href="http://r-lib.github.io/desc/reference/desc_set_version.html" class="external-link">desc::desc_set_version()</a></code>, commits and push to git

--- a/docs/reference/style_all.html
+++ b/docs/reference/style_all.html
@@ -18,7 +18,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/to_document.html
+++ b/docs/reference/to_document.html
@@ -18,7 +18,7 @@ html_notebook to html_document, removing all other output types."><!-- mathjax -
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/update_wordlist_notebooks.html
+++ b/docs/reference/update_wordlist_notebooks.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/use_analysis_package.html
+++ b/docs/reference/use_analysis_package.html
@@ -18,7 +18,7 @@ to the current package."><!-- mathjax --><script src="https://cdnjs.cloudflare.c
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/use_codecov.html
+++ b/docs/reference/use_codecov.html
@@ -18,7 +18,7 @@ DT package for covr::report(), and rdev GitHub action test-coverage.yaml.'><!-- 
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/use_lintr.html
+++ b/docs/reference/use_lintr.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/use_package_r.html
+++ b/docs/reference/use_package_r.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/use_rdev_package.html
+++ b/docs/reference/use_rdev_package.html
@@ -18,7 +18,7 @@ up a package."><!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/li
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/use_rprofile.html
+++ b/docs/reference/use_rprofile.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/use_spelling.html
+++ b/docs/reference/use_spelling.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/docs/reference/use_todo.html
+++ b/docs/reference/use_todo.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rdev</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.3.3</span>
       </span>
     </div>
 

--- a/man/stage_release.Rd
+++ b/man/stage_release.Rd
@@ -33,7 +33,7 @@ When run, \code{stage_release()}:
 \item Extracts release version and release notes from \code{NEWS.md} using \code{\link[=get_release]{get_release()}}
 \item Validates version conforms to rdev conventions (#.#.#) and release notes aren't empty
 \item Verifies that version tag doesn't already exist using \code{\link[gert:git_tag]{gert::git_tag_list()}}
-\item Checks for uncommitted changes and stops if any exist using \code{\link[gert:git_diff]{gert::git_diff_patch()}}
+\item Checks for uncommitted changes and stops if any exist using \code{\link[gert:git_commit]{gert::git_status()}}
 \item Creates a new branch if on the default branch (\code{\link[gert:git_branch]{gert::git_branch()}} \code{==}
 \code{\link[usethis:git-default-branch]{usethis::git_default_branch()}}) using \code{\link[gert:git_branch]{gert::git_branch_create()}}
 \item Updates \code{Version} in \code{DESCRIPTION} with \code{\link[desc:desc_set_version]{desc::desc_set_version()}}, commits and push to git

--- a/renv.lock
+++ b/renv.lock
@@ -594,9 +594,9 @@
       "RemoteUsername": "r-lib",
       "RemoteRepo": "lintr",
       "RemoteRef": "master",
-      "RemoteSha": "7dd6dff8a743b9fd1d7cce53a2c7eb48fdef2661",
+      "RemoteSha": "23fec9529122dd5fbcaba132ca62d9f62ef04c93",
       "RemoteHost": "api.github.com",
-      "Hash": "c1d03c25448fd945c1d7b36ec73e4922",
+      "Hash": "5c471276a602b9b976532adb4a957a85",
       "Requirements": [
         "codetools",
         "crayon",

--- a/tests/testthat/test-release.R
+++ b/tests/testthat/test-release.R
@@ -1,4 +1,12 @@
 withr::local_dir("test-release")
+git_status_empty <- structure(
+  list(file = character(0), status = character(0), staged = logical(0)),
+  row.names = integer(0), class = c("tbl_df", "tbl", "data.frame")
+)
+git_status_changed <- structure(
+  list(file = "test", status = "new", staged = FALSE),
+  row.names = c(NA, -1L), class = c("tbl_df", "tbl", "data.frame")
+)
 
 # new_branch
 
@@ -221,7 +229,7 @@ test_that("stage_release returns error if uncommitted changes are present", {
   rel <- get_release()
   mockery::stub(stage_release, "get_release", rel)
   mockery::stub(stage_release, "gert::git_tag_list", no_tags)
-  mockery::stub(stage_release, "gert::git_diff_patch", c("diff --git fake/1"))
+  mockery::stub(stage_release, "gert::git_status", git_status_changed)
   # stub functions that change state
   mockery::stub(stage_release, "gert::git_branch_create", NULL)
   mockery::stub(stage_release, "desc::desc_set_version", NULL)
@@ -243,7 +251,7 @@ test_that("stage_release creates new branch", {
   rel <- get_release()
   mockery::stub(stage_release, "get_release", rel)
   mockery::stub(stage_release, "gert::git_tag_list", no_tags)
-  mockery::stub(stage_release, "gert::git_diff_patch", character(0))
+  mockery::stub(stage_release, "gert::git_status", git_status_empty)
   mockery::stub(stage_release, "gert::git_branch", "main")
   mockery::stub(stage_release, "usethis::git_default_branch", "main")
   # stub functions that change state
@@ -270,7 +278,7 @@ test_that("stage_release errors when on default branch before commits", {
   rel <- get_release()
   mockery::stub(stage_release, "get_release", rel)
   mockery::stub(stage_release, "gert::git_tag_list", no_tags)
-  mockery::stub(stage_release, "gert::git_diff_patch", character(0))
+  mockery::stub(stage_release, "gert::git_status", git_status_empty)
   mockery::stub(stage_release, "usethis::git_default_branch", "main")
   mockery::stub(stage_release, "gert::git_branch", "main")
   # stub functions that change state
@@ -294,7 +302,7 @@ test_that("stage_release runs proper builder", {
   rel <- get_release()
   mockery::stub(stage_release, "get_release", rel)
   mockery::stub(stage_release, "gert::git_tag_list", no_tags)
-  mockery::stub(stage_release, "gert::git_diff_patch", character(0))
+  mockery::stub(stage_release, "gert::git_status", git_status_empty)
   mockery::stub(stage_release, "usethis::git_default_branch", "main")
   mockery::stub(stage_release, "gert::git_branch", "stage-release")
   mockery::stub(stage_release, "gert::git_remote_info", NULL)
@@ -336,7 +344,7 @@ test_that("stage_release returns pull request results", {
   rel <- get_release()
   mockery::stub(stage_release, "get_release", rel)
   mockery::stub(stage_release, "gert::git_tag_list", no_tags)
-  mockery::stub(stage_release, "gert::git_diff_patch", character(0))
+  mockery::stub(stage_release, "gert::git_status", git_status_empty)
   mockery::stub(stage_release, "usethis::git_default_branch", "main")
   mockery::stub(stage_release, "gert::git_branch", "stage-release")
   rem <- list(name = "origin", url = "https://github.com/example/test.git")


### PR DESCRIPTION
* Fixed `ci()` and `stage_release()` to correctly use `gert::git_stage()` to determine if uncommitted changes exist (instead of `gert::git_diff_patch()`)