### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'release'}
+          - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           # - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           # - {os: ubuntu-latest,   r: 'release'}
@@ -29,7 +29,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,12 +10,12 @@ name: lint
 
 jobs:
   lint:
-    runs-on: macOS-latest
+    runs-on: macos-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-r@v2
 
@@ -25,8 +25,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Lint all files
-        run: |
-          lints <- lintr::lint_dir(path = ".")
-          lints
-          stopifnot(length(lints) == 0)
+        run: lintr::lint_dir(path = ".")
         shell: Rscript {0}
+        env:
+          LINTR_ERROR_ON_LINT: true

--- a/.github/workflows/missing-deps.yaml
+++ b/.github/workflows/missing-deps.yaml
@@ -6,11 +6,11 @@ on:
   pull_request:
     branches: [main, master]
 
-name: lint
+name: missing-deps
 
 jobs:
-  lint:
-    runs-on: macOS-latest
+  missing-deps:
+    runs-on: macos-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
@@ -21,12 +21,12 @@ jobs:
 
       - uses: r-lib/actions/setup-renv@v2
       - name: Install dependencies
-        run: renv::install(c("rdev"))
+        run: renv::install("jabenninghoff/rdev")
         shell: Rscript {0}
 
       - name: Find missing dependencies
         run: |
-          mdeps <- missing_deps(exclude_base = TRUE)
+          mdeps <- rdev::missing_deps()
           mdeps
           stopifnot(nrow(mdeps) == 0)
         shell: Rscript {0}

--- a/.github/workflows/missing-deps.yaml
+++ b/.github/workflows/missing-deps.yaml
@@ -1,0 +1,32 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: lint
+
+jobs:
+  lint:
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - uses: r-lib/actions/setup-renv@v2
+      - name: Install dependencies
+        run: renv::install(c("rdev"))
+        shell: Rscript {0}
+
+      - name: Find missing dependencies
+        run: |
+          mdeps <- missing_deps(exclude_base = TRUE)
+          mdeps
+          stopifnot(nrow(mdeps) == 0)
+        shell: Rscript {0}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -10,12 +10,12 @@ name: test-coverage
 
 jobs:
   test-coverage:
-    runs-on: macOS-latest
+    runs-on: macos-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-r@v2
 
@@ -27,5 +27,24 @@ jobs:
       - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Test coverage
-        run: covr::codecov(quiet = FALSE)
+        run: |
+          covr::codecov(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(Sys.getenv("RUNNER_TEMP"), "package")
+          )
         shell: Rscript {0}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,7 @@ URL: https://jabenninghoff.github.io/rdev/,
 BugReports: https://github.com/jabenninghoff/rdev/issues
 Imports:
     cli,
+    curl,
     desc,
     devtools,
     fs,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rdev
 Title: R Development Tools
-Version: 1.6.1
+Version: 1.6.1.9000
 Authors@R:
     person("John", "Benninghoff", , "jbenninghoff@mac.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6230-4742"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,4 +52,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# rdev 1.6.2
+
+* `missing_deps()` now excludes base R packages by default
+
+* Added new checks to `ci()`: `missing_deps()`, `desc::desc_normalize()`, `extra_deps()`, `url_check()`, and `html_url_check()`; `ci()` will stop if `missing_deps()` returns one or more rows
+
+* Added `missing-deps.yaml` GitHub Action
+
 # rdev 1.6.1
 
 * `new_branch()` now stashes and restores changes, so that the `Bump version` commit just changes the version number in `DESCRIPTION`

--- a/R/setup.R
+++ b/R/setup.R
@@ -459,24 +459,21 @@ use_analysis_package <- function(prompt = FALSE) {
   # workaround for lintr, R CMD check
   create <- gitignore <- rbuildignore <- NULL
 
-  # TODO: update to styler >= 1.7.1 (or greater) when released
-  # alignment detection not working for 3+ columns: https://github.com/r-lib/styler/issues/943
-  # fixed by https://github.com/r-lib/styler/pull/945
   analysis_layout <- tibble::tribble(
-    ~pattern, ~create, ~gitignore, ~rbuildignore,
-    "analysis", TRUE, FALSE, FALSE,
-    "analysis/*.docx", FALSE, TRUE, TRUE,
-    "analysis/*.html", FALSE, TRUE, TRUE,
-    "analysis/*.md", FALSE, TRUE, TRUE,
-    "analysis/*.pdf", FALSE, TRUE, TRUE,
-    "analysis/*-figure/", FALSE, TRUE, TRUE,
-    "analysis/assets", TRUE, FALSE, FALSE,
-    "analysis/data", TRUE, FALSE, FALSE,
-    "analysis/import", TRUE, TRUE, TRUE,
-    "analysis/rendered", TRUE, TRUE, TRUE,
-    "docs", TRUE, FALSE, TRUE,
-    "pkgdown", TRUE, FALSE, TRUE,
-    "_pkgdown.yml", FALSE, FALSE, TRUE
+    ~pattern,             ~create, ~gitignore, ~rbuildignore,
+    "analysis",           TRUE,    FALSE,      FALSE,
+    "analysis/*.docx",    FALSE,   TRUE,       TRUE,
+    "analysis/*.html",    FALSE,   TRUE,       TRUE,
+    "analysis/*.md",      FALSE,   TRUE,       TRUE,
+    "analysis/*.pdf",     FALSE,   TRUE,       TRUE,
+    "analysis/*-figure/", FALSE,   TRUE,       TRUE,
+    "analysis/assets",    TRUE,    FALSE,      FALSE,
+    "analysis/data",      TRUE,    FALSE,      FALSE,
+    "analysis/import",    TRUE,    TRUE,       TRUE,
+    "analysis/rendered",  TRUE,    TRUE,       TRUE,
+    "docs",               TRUE,    FALSE,      TRUE,
+    "pkgdown",            TRUE,    FALSE,      TRUE,
+    "_pkgdown.yml",       FALSE,   FALSE,      TRUE
   )
 
   analysis_dirs <- subset(analysis_layout, create)$pattern

--- a/R/urlchecker.R
+++ b/R/urlchecker.R
@@ -16,9 +16,13 @@ url_check <- urlchecker::url_check
 # NOTE: url_update code includes cli::cli_alert_success which creates a warning in R CMD check if
 # cli is not recorded in Imports. This function is a workaround to ensure use of cli is also
 # detected by renv.
-# TODO: open upstream issue (renv) and/or implement a better fix.
 url_update_renv_workaround <- function(...) {
   cli::cli_alert_success(...)
+}
+
+# NOTE: use of curl::new_pool() is considered a dependency by renv but not by R CMD check.
+curl_new_pool_renv_workaround <- function(...) {
+  curl::new_pool(...)
 }
 
 #' @rdname urlchecker-reexports
@@ -37,8 +41,6 @@ url_update <- urlchecker::url_update
 #' @return A `url_checker_db` object (invisibly). This is a `check_url_db` object with an added
 #'   class with a custom print method.
 #' @export
-# NOTE: use of curl::new_pool() is considered a dependency by renv but not by R CMD check.
-# TODO: open upstream issue (renv) and/or implement a fix.
 html_url_check <- function(path = "docs", parallel = TRUE, pool = curl::new_pool(),
                            progress = TRUE) {
   # nocov start

--- a/R/utils.R
+++ b/R/utils.R
@@ -165,7 +165,7 @@ deps_check <- function(type, exclude_base = TRUE) {
 #'
 #' The current package ([`pkgload::pkg_name(".")`][pkgload::pkg_name()]) and `renv` (in `renv.lock`
 #'   only) are automatically removed from [renv::dependencies()], along with 'base' R packages if
-#'   `exclude_base` is `TRUE` (`r rownames(installed.packages(priority = "base"))`).
+#'   `exclude_base` is `TRUE` (`r sort(rownames(installed.packages(priority = "base")))`).
 #'
 #' @param exclude_base exclude packages installed with R from missing dependencies
 #'

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -40,6 +40,7 @@ gh's
 github
 gitignore
 globbing
+grDevices
 htmlproofer
 https
 hunspell
@@ -67,6 +68,7 @@ rprofile
 rstudio
 rtraining
 styler
+tcltk
 testthat
 tidyverse
 urlchecker

--- a/man/ci.Rd
+++ b/man/ci.Rd
@@ -4,7 +4,17 @@
 \alias{ci}
 \title{Local CI}
 \usage{
-ci(renv = TRUE, styler = NULL, lintr = TRUE, document = TRUE, rcmdcheck = TRUE)
+ci(
+  renv = TRUE,
+  styler = NULL,
+  lintr = TRUE,
+  document = TRUE,
+  normalize = TRUE,
+  rcmdcheck = TRUE,
+  missing = TRUE,
+  extra = TRUE,
+  urls = TRUE
+)
 }
 \arguments{
 \item{renv}{check \code{\link[renv:status]{renv::status()}}}
@@ -15,8 +25,16 @@ ci(renv = TRUE, styler = NULL, lintr = TRUE, document = TRUE, rcmdcheck = TRUE)
 
 \item{document}{run \code{\link[devtools:document]{devtools::document()}}}
 
-\item{rcmdcheck}{run \code{R CMD check} using:
+\item{normalize}{run \code{\link[desc:desc_normalize]{desc::desc_normalize()}}}
+
+\item{rcmdcheck}{run \verb{R CMD check} using:
 \code{\link[rcmdcheck:rcmdcheck]{rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning")}}}
+
+\item{missing}{run \code{\link[=missing_deps]{missing_deps()}}}
+
+\item{extra}{run \code{\link[=extra_deps]{extra_deps()}}}
+
+\item{urls}{validate URLs with \code{\link[=url_check]{url_check()}} and \code{\link[=html_url_check]{html_url_check()}}}
 }
 \description{
 Run continuous integration tests locally.
@@ -28,6 +46,9 @@ If \code{styler} is set to \code{NULL} (the default), \code{\link[=style_all]{st
 uncommitted changes to git. Setting the value to \code{TRUE} or \code{FALSE} overrides this check.
 
 If \code{\link[=lint_all]{lint_all()}} finds any lints, \code{ci()} will stop and open the RStudio markers pane.
+
+Output from \code{missing}, \code{extra}, and \code{urls} is printed as a \link[tibble:tibble]{tibble} for
+improved readability in the console.
 }
 \examples{
 \dontrun{

--- a/man/ci.Rd
+++ b/man/ci.Rd
@@ -6,18 +6,20 @@
 \usage{
 ci(
   renv = TRUE,
+  missing = TRUE,
   styler = NULL,
   lintr = TRUE,
   document = TRUE,
   normalize = TRUE,
   rcmdcheck = TRUE,
-  missing = TRUE,
   extra = TRUE,
   urls = TRUE
 )
 }
 \arguments{
 \item{renv}{check \code{\link[renv:status]{renv::status()}}}
+
+\item{missing}{run \code{\link[=missing_deps]{missing_deps()}}}
 
 \item{styler}{style all files using \code{\link[=style_all]{style_all()}}, see details}
 
@@ -30,8 +32,6 @@ ci(
 \item{rcmdcheck}{run \verb{R CMD check} using:
 \code{\link[rcmdcheck:rcmdcheck]{rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning")}}}
 
-\item{missing}{run \code{\link[=missing_deps]{missing_deps()}}}
-
 \item{extra}{run \code{\link[=extra_deps]{extra_deps()}}}
 
 \item{urls}{validate URLs with \code{\link[=url_check]{url_check()}} and \code{\link[=html_url_check]{html_url_check()}}}
@@ -41,6 +41,8 @@ Run continuous integration tests locally.
 }
 \details{
 If \code{\link[renv:status]{renv::status()}} is not synchronized, \code{ci()} will stop.
+
+If \code{\link[=missing_deps]{missing_deps()}} returns any missing dependencies, \code{ci()} will stop.
 
 If \code{styler} is set to \code{NULL} (the default), \code{\link[=style_all]{style_all()}} will be run only if there are no
 uncommitted changes to git. Setting the value to \code{TRUE} or \code{FALSE} overrides this check.

--- a/man/deps_check.Rd
+++ b/man/deps_check.Rd
@@ -25,5 +25,5 @@ Check dependencies in DESCRIPTION.
 
 The current package (\code{\link[pkgload:packages]{pkgload::pkg_name(".")}}) and \code{renv} (in \code{renv.lock}
 only) are automatically removed from \code{\link[renv:dependencies]{renv::dependencies()}}, along with 'base' R packages if
-\code{exclude_base} is \code{TRUE} (base, compiler, datasets, graphics, grDevices, grid, methods, parallel, splines, stats, stats4, tcltk, tools, utils).
+\code{exclude_base} is \code{TRUE} (base, compiler, datasets, grDevices, graphics, grid, methods, parallel, splines, stats, stats4, tcltk, tools, utils).
 }

--- a/man/deps_check.Rd
+++ b/man/deps_check.Rd
@@ -5,9 +5,12 @@
 \alias{extra_deps}
 \title{Check dependencies}
 \usage{
-missing_deps()
+missing_deps(exclude_base = TRUE)
 
 extra_deps()
+}
+\arguments{
+\item{exclude_base}{exclude packages installed with R from missing dependencies}
 }
 \value{
 data.frame from either \code{\link[renv:dependencies]{renv::dependencies()}} or \code{\link[desc:desc_get_deps]{desc::desc_get_deps()}}.
@@ -21,5 +24,6 @@ Check dependencies in DESCRIPTION.
 \code{extra_deps()} reports \code{\link[desc:desc_get_deps]{desc::desc_get_deps()}} not found by renv.
 
 The current package (\code{\link[pkgload:packages]{pkgload::pkg_name(".")}}) and \code{renv} (in \code{renv.lock}
-only) are automatically removed from \code{\link[renv:dependencies]{renv::dependencies()}}.
+only) are automatically removed from \code{\link[renv:dependencies]{renv::dependencies()}}, along with 'base' R packages if
+\code{exclude_base} is \code{TRUE} (base, compiler, datasets, graphics, grDevices, grid, methods, parallel, splines, stats, stats4, tcltk, tools, utils).
 }

--- a/man/style_all.Rd
+++ b/man/style_all.Rd
@@ -18,14 +18,14 @@ standardization) are: "r", "rprofile", "rmd", "rmarkdown", "rnw". Rmarkdown is t
   Arguments passed on to \code{\link[styler:style_dir]{styler::style_dir}}
   \describe{
     \item{\code{style}}{A function that creates a style guide to use, by default
-\code{\link[styler:tidyverse_style]{tidyverse_style()}} (without the parentheses). Not used
+\code{\link[styler]{tidyverse_style}}. Not used
 further except to construct the argument \code{transformers}. See
 \code{\link[styler:style_guides]{style_guides()}} for details.}
     \item{\code{transformers}}{A set of transformer functions. This argument is most
 conveniently constructed via the \code{style} argument and \code{...}. See
 'Examples'.}
-    \item{\code{recursive}}{A logical value indicating whether or not files in subdirectories
-of \code{path} should be styled as well.}
+    \item{\code{recursive}}{A logical value indicating whether or not files in
+sub directories of \code{path} should be styled as well.}
     \item{\code{exclude_files}}{Character vector with paths to files that should be
 excluded from styling.}
     \item{\code{exclude_dirs}}{Character vector with directories to exclude

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.2.1",
+    "Version": "4.2.2",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -11,10 +11,10 @@
   "Packages": {
     "DT": {
       "Package": "DT",
-      "Version": "0.25",
+      "Version": "0.26",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "d35337fd4278be35c50d7eeeec439f68",
+      "Hash": "c66a72c4d3499e14ae179ccb742e740a",
       "Requirements": [
         "crosstalk",
         "htmltools",
@@ -58,10 +58,10 @@
     },
     "R.utils": {
       "Package": "R.utils",
-      "Version": "2.12.0",
+      "Version": "2.12.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "d31333e10f14027e1cbbc6f266512806",
+      "Hash": "325f01db13da12c04d8f6e7be36ff514",
       "Requirements": [
         "R.methodsS3",
         "R.oo"
@@ -111,10 +111,10 @@
     },
     "brew": {
       "Package": "brew",
-      "Version": "1.0-7",
+      "Version": "1.0-8",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "38875ea52350ff4b4c03849fc69736c8",
+      "Hash": "d69a786e85775b126bddbee185ae6084",
       "Requirements": []
     },
     "brio": {
@@ -127,16 +127,18 @@
     },
     "bslib": {
       "Package": "bslib",
-      "Version": "0.4.0",
+      "Version": "0.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "be5ee090716ce1671be6cd5d7c34d091",
+      "Hash": "a7fbf03946ad741129dc81098722fca1",
       "Requirements": [
+        "base64enc",
         "cachem",
         "htmltools",
         "jquerylib",
         "jsonlite",
         "memoise",
+        "mime",
         "rlang",
         "sass"
       ]
@@ -154,10 +156,10 @@
     },
     "callr": {
       "Package": "callr",
-      "Version": "3.7.2",
+      "Version": "3.7.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "358689cac9fe93b1bb3a19088d2dbed8",
+      "Hash": "9b2191ede20fa29828139b9900922e51",
       "Requirements": [
         "R6",
         "processx"
@@ -165,10 +167,10 @@
     },
     "cli": {
       "Package": "cli",
-      "Version": "3.4.1",
+      "Version": "3.6.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "0d297d01734d2bcea40197bd4971a764",
+      "Hash": "3177a5a16c243adc199ba33117bd9657",
       "Requirements": []
     },
     "clipr": {
@@ -189,10 +191,10 @@
     },
     "commonmark": {
       "Package": "commonmark",
-      "Version": "1.8.0",
+      "Version": "1.8.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "2ba81b120c1655ab696c935ef33ea716",
+      "Hash": "b6e3e947d1d7ebf3d2bdcea1bde63fe7",
       "Requirements": []
     },
     "covr": {
@@ -213,18 +215,18 @@
     },
     "cpp11": {
       "Package": "cpp11",
-      "Version": "0.4.2",
+      "Version": "0.4.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "fa53ce256cd280f468c080a58ea5ba8c",
+      "Hash": "ed588261931ee3be2c700d22e94a29ab",
       "Requirements": []
     },
     "crayon": {
       "Package": "crayon",
-      "Version": "1.5.1",
+      "Version": "1.5.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "8dc45fd8a1ee067a92b85ef274e66d6a",
+      "Hash": "e8a1e41acf02548751f45c718d55aa6a",
       "Requirements": []
     },
     "credentials": {
@@ -256,10 +258,10 @@
     },
     "curl": {
       "Package": "curl",
-      "Version": "4.3.2",
+      "Version": "5.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "022c42d49c28e95d69ca60446dbabf88",
+      "Hash": "e4f97056611e8e6b8b852d13b7400cf1",
       "Requirements": []
     },
     "cyclocomp": {
@@ -290,10 +292,10 @@
     },
     "devtools": {
       "Package": "devtools",
-      "Version": "2.4.4",
+      "Version": "2.4.5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "d6ad91ae6533b84d227bb0b5262c111f",
+      "Hash": "ea5bc8b4a6a01e4f12d98b58329930bb",
       "Requirements": [
         "cli",
         "desc",
@@ -341,10 +343,10 @@
     },
     "digest": {
       "Package": "digest",
-      "Version": "0.6.29",
+      "Version": "0.6.31",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "cf6b206a045a684728c3267ef7596190",
+      "Hash": "8b708f296afd9ae69f450f9640be8990",
       "Requirements": []
     },
     "downlit": {
@@ -378,10 +380,10 @@
     },
     "evaluate": {
       "Package": "evaluate",
-      "Version": "0.16",
+      "Version": "0.19",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "9a3d3c345f8a5648abe61608aaa29518",
+      "Hash": "5aac3cd0a3ccb1a738941796b28c26fe",
       "Requirements": []
     },
     "fansi": {
@@ -402,10 +404,10 @@
     },
     "fontawesome": {
       "Package": "fontawesome",
-      "Version": "0.3.0",
+      "Version": "0.4.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "a36c4a3eade472039a3ec8cb824e6dc4",
+      "Hash": "c5a628c2570aa86a96cc6ef739d8bfda",
       "Requirements": [
         "htmltools",
         "rlang"
@@ -421,10 +423,10 @@
     },
     "gert": {
       "Package": "gert",
-      "Version": "1.9.0",
+      "Version": "1.9.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "56dc795889978f759ea0b0de06dcd5b4",
+      "Hash": "9122b3958e749badb5c939f498038b57",
       "Requirements": [
         "askpass",
         "credentials",
@@ -466,45 +468,48 @@
     },
     "highr": {
       "Package": "highr",
-      "Version": "0.9",
+      "Version": "0.10",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "8eb36c8125038e648e5d111c0d7b2ed4",
+      "Hash": "06230136b2d2b9ba5805e1963fa6e890",
       "Requirements": [
         "xfun"
       ]
     },
     "htmltools": {
       "Package": "htmltools",
-      "Version": "0.5.3",
+      "Version": "0.5.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6496090a9e00f8354b811d1a2d47b566",
+      "Hash": "9d27e99cc90bd701c0a7a63e5923f9b7",
       "Requirements": [
         "base64enc",
         "digest",
+        "ellipsis",
         "fastmap",
         "rlang"
       ]
     },
     "htmlwidgets": {
       "Package": "htmlwidgets",
-      "Version": "1.5.4",
+      "Version": "1.6.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "76147821cd3fcd8c4b04e1ef0498e7fb",
+      "Hash": "b677ee5954471eaa974c0d099a343a1a",
       "Requirements": [
         "htmltools",
         "jsonlite",
+        "knitr",
+        "rmarkdown",
         "yaml"
       ]
     },
     "httpuv": {
       "Package": "httpuv",
-      "Version": "1.6.6",
+      "Version": "1.6.8",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "fd090e236ae2dc0f0cdf33a9ec83afb6",
+      "Hash": "08e611aee165b27f8ff18770285fb535",
       "Requirements": [
         "R6",
         "Rcpp",
@@ -557,18 +562,18 @@
     },
     "jsonlite": {
       "Package": "jsonlite",
-      "Version": "1.8.0",
+      "Version": "1.8.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "d07e729b27b372429d42d24d503613a0",
+      "Hash": "a4269a09a9b865579b2635c77e572374",
       "Requirements": []
     },
     "knitr": {
       "Package": "knitr",
-      "Version": "1.40",
+      "Version": "1.41",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "caea8b0f899a0b1738444b9bc47067e7",
+      "Hash": "6d4971f3610e75220534a1befe81bc92",
       "Requirements": [
         "evaluate",
         "highr",
@@ -598,21 +603,22 @@
     },
     "lifecycle": {
       "Package": "lifecycle",
-      "Version": "1.0.2",
+      "Version": "1.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "25f74670fa7d3277fe3ad8c1712a699f",
+      "Hash": "001cecbeac1cff9301bdc3775ee46a86",
       "Requirements": [
+        "cli",
         "glue",
         "rlang"
       ]
     },
     "lintr": {
       "Package": "lintr",
-      "Version": "3.0.1",
+      "Version": "3.0.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "41ca4b419351698a49c3a74f0281ffbd",
+      "Hash": "b21ebd652d940f099915221f3328ab7b",
       "Requirements": [
         "backports",
         "codetools",
@@ -637,11 +643,12 @@
     },
     "markdown": {
       "Package": "markdown",
-      "Version": "1.1",
+      "Version": "1.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "61e4a10781dd00d7d81dd06ca9b94e95",
+      "Hash": "f99f5d2d7b2c2c031343bfa7b9f97980",
       "Requirements": [
+        "commonmark",
         "mime",
         "xfun"
       ]
@@ -688,10 +695,10 @@
     },
     "openssl": {
       "Package": "openssl",
-      "Version": "2.0.3",
+      "Version": "2.0.5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "b9621e75c0652041002a19609fb23c5a",
+      "Hash": "b04c27110bf367b4daa93f34f3d58e75",
       "Requirements": [
         "askpass"
       ]
@@ -714,10 +721,10 @@
     },
     "pkgbuild": {
       "Package": "pkgbuild",
-      "Version": "1.3.1",
+      "Version": "1.4.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "66d2adfed274daf81ccfe77d974c3b9b",
+      "Hash": "d6c3008d79653a0f267703288230105e",
       "Requirements": [
         "R6",
         "callr",
@@ -725,6 +732,7 @@
         "crayon",
         "desc",
         "prettyunits",
+        "processx",
         "rprojroot",
         "withr"
       ]
@@ -739,10 +747,10 @@
     },
     "pkgdown": {
       "Package": "pkgdown",
-      "Version": "2.0.6",
+      "Version": "2.0.7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "f958d0b2a5dabc5ffd414f062b1ffbe7",
+      "Hash": "16fa15449c930bf3a7761d3c68f8abf9",
       "Requirements": [
         "bslib",
         "callr",
@@ -768,10 +776,10 @@
     },
     "pkgload": {
       "Package": "pkgload",
-      "Version": "1.3.0",
+      "Version": "1.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "4b20f937a363c78a5730265c1925f54a",
+      "Hash": "6b0c222c5071efe0f3baf3dae9aa40e2",
       "Requirements": [
         "cli",
         "crayon",
@@ -801,10 +809,10 @@
     },
     "processx": {
       "Package": "processx",
-      "Version": "3.7.0",
+      "Version": "3.8.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "f91df0f5f31ffdf88bc0b624f5ebab0f",
+      "Hash": "a33ee2d9bf07564efb888ad98410da84",
       "Requirements": [
         "R6",
         "ps"
@@ -837,29 +845,32 @@
     },
     "ps": {
       "Package": "ps",
-      "Version": "1.7.1",
+      "Version": "1.7.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "8b93531308c01ad0e56d9eadcc0c4fcd",
+      "Hash": "68dd03d98a5efd1eb3012436de45ba83",
       "Requirements": []
     },
     "purrr": {
       "Package": "purrr",
-      "Version": "0.3.4",
+      "Version": "1.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "97def703420c8ab10d8f0e6c72101e02",
+      "Hash": "d71c815267c640f17ddbf7f16144b4bb",
       "Requirements": [
+        "cli",
+        "lifecycle",
         "magrittr",
-        "rlang"
+        "rlang",
+        "vctrs"
       ]
     },
     "ragg": {
       "Package": "ragg",
-      "Version": "1.2.2",
+      "Version": "1.2.5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "14932bb6f2739c771ca4ceaba6b4248e",
+      "Hash": "690bc058ea2b1b8a407d3cfe3dce3ef9",
       "Requirements": [
         "systemfonts",
         "textshaping"
@@ -914,10 +925,10 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "0.15.5",
+      "Version": "0.16.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6a38294e7d12f5d8e656b08c5bd8ae34",
+      "Hash": "c9e8442ab69bc21c9697ecf856c1e6c7",
       "Requirements": []
     },
     "rex": {
@@ -940,10 +951,10 @@
     },
     "rmarkdown": {
       "Package": "rmarkdown",
-      "Version": "2.16",
+      "Version": "2.19",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "0f3eaa1547e2c6880d4de1c043ac6826",
+      "Hash": "4e29299e1f4c7eabb0b8365b338adf3c",
       "Requirements": [
         "bslib",
         "evaluate",
@@ -959,10 +970,10 @@
     },
     "roxygen2": {
       "Package": "roxygen2",
-      "Version": "7.2.1",
+      "Version": "7.2.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "da1f278262e563c835345872f2fef537",
+      "Hash": "7b153c746193b143c14baa072bae4e27",
       "Requirements": [
         "R6",
         "brew",
@@ -970,7 +981,6 @@
         "commonmark",
         "cpp11",
         "desc",
-        "digest",
         "knitr",
         "pkgload",
         "purrr",
@@ -1010,10 +1020,10 @@
     },
     "sass": {
       "Package": "sass",
-      "Version": "0.4.2",
+      "Version": "0.4.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "1b191143d7d3444d504277843f3a95fe",
+      "Hash": "c76cbac7ca04ce82d8c38e29729987a3",
       "Requirements": [
         "R6",
         "fs",
@@ -1034,10 +1044,10 @@
     },
     "shiny": {
       "Package": "shiny",
-      "Version": "1.7.2",
+      "Version": "1.7.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "4f7970a3edb0a153ac6b376785a1944a",
+      "Hash": "c2eae3d8c670fa9dfa35a12066f4a1d5",
       "Requirements": [
         "R6",
         "bslib",
@@ -1084,48 +1094,51 @@
     },
     "stringi": {
       "Package": "stringi",
-      "Version": "1.7.8",
+      "Version": "1.7.12",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "a68b980681bcbc84c7a67003fa796bfb",
+      "Hash": "ca8bd84263c77310739d2cf64d84d7c9",
       "Requirements": []
     },
     "stringr": {
       "Package": "stringr",
-      "Version": "1.4.1",
+      "Version": "1.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "a66ad12140cd34d4f9dfcc19e84fc2a5",
+      "Hash": "671a4d384ae9d32fc47a14e98bfa3dc8",
       "Requirements": [
+        "cli",
         "glue",
+        "lifecycle",
         "magrittr",
-        "stringi"
+        "rlang",
+        "stringi",
+        "vctrs"
       ]
     },
     "styler": {
       "Package": "styler",
-      "Version": "1.7.0",
+      "Version": "1.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6cc6b1eb8f318b15fae4b81fe0a0d82e",
+      "Hash": "1c038945a5e14cce208f5214c1dd167c",
       "Requirements": [
         "R.cache",
         "cli",
         "magrittr",
         "purrr",
-        "rematch2",
         "rlang",
         "rprojroot",
-        "tibble",
+        "vctrs",
         "withr"
       ]
     },
     "sys": {
       "Package": "sys",
-      "Version": "3.4",
+      "Version": "3.4.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "b227d13e29222b4574486cfcbde077fa",
+      "Hash": "34c16f1ef796057bfa06d3f4ff818a5d",
       "Requirements": []
     },
     "systemfonts": {
@@ -1140,16 +1153,15 @@
     },
     "testthat": {
       "Package": "testthat",
-      "Version": "3.1.4",
+      "Version": "3.1.6",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "f76c2a02d0fdc24aa7a47ea34261a6e3",
+      "Hash": "7910146255835c66e9eb272fb215248d",
       "Requirements": [
         "R6",
         "brio",
         "callr",
         "cli",
-        "crayon",
         "desc",
         "digest",
         "ellipsis",
@@ -1195,10 +1207,10 @@
     },
     "tinytex": {
       "Package": "tinytex",
-      "Version": "0.41",
+      "Version": "0.43",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6edfe5df6431a724b4254c0591e34ab3",
+      "Hash": "facc02f3d63ed7dd765513c004c394ce",
       "Requirements": [
         "xfun"
       ]
@@ -1253,13 +1265,14 @@
     },
     "vctrs": {
       "Package": "vctrs",
-      "Version": "0.4.1",
+      "Version": "0.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "8b54f22e2a58c4f275479c92ce041a57",
+      "Hash": "970324f6572b4fd81db507b5d4062cb0",
       "Requirements": [
         "cli",
         "glue",
+        "lifecycle",
         "rlang"
       ]
     },
@@ -1281,10 +1294,10 @@
     },
     "whisker": {
       "Package": "whisker",
-      "Version": "0.4",
+      "Version": "0.4.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "ca970b96d894e90397ed20637a0c1bbe",
+      "Hash": "c6abfa47a46d281a7d5159d0a8891e88",
       "Requirements": []
     },
     "withr": {
@@ -1297,10 +1310,10 @@
     },
     "xfun": {
       "Package": "xfun",
-      "Version": "0.33",
+      "Version": "0.36",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "1a666f915cd65072f4ccf5b2888d5d39",
+      "Hash": "f5baec54606751aa53ac9c0e05848ed6",
       "Requirements": []
     },
     "xml2": {
@@ -1339,18 +1352,18 @@
     },
     "yaml": {
       "Package": "yaml",
-      "Version": "2.3.5",
+      "Version": "2.3.6",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "458bb38374d73bf83b1bb85e353da200",
+      "Hash": "9b570515751dcbae610f29885e025b41",
       "Requirements": []
     },
     "zip": {
       "Package": "zip",
-      "Version": "2.2.1",
+      "Version": "2.2.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "a7e91189fa51d9029a30eba3831ce53f",
+      "Hash": "c42bfcec3fa6a0cce17ce1f8bc684f88",
       "Requirements": []
     }
   }

--- a/renv.lock
+++ b/renv.lock
@@ -11,10 +11,10 @@
   "Packages": {
     "DT": {
       "Package": "DT",
-      "Version": "0.26",
+      "Version": "0.27",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "c66a72c4d3499e14ae179ccb742e740a",
+      "Hash": "3444e6ed78763f9f13aaa39f2481eb34",
       "Requirements": [
         "crosstalk",
         "htmltools",
@@ -380,10 +380,10 @@
     },
     "evaluate": {
       "Package": "evaluate",
-      "Version": "0.19",
+      "Version": "0.20",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "5aac3cd0a3ccb1a738941796b28c26fe",
+      "Hash": "4b68aa51edd89a0e044a66e75ae3cc6c",
       "Requirements": []
     },
     "fansi": {
@@ -951,10 +951,10 @@
     },
     "rmarkdown": {
       "Package": "rmarkdown",
-      "Version": "2.19",
+      "Version": "2.20",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "4e29299e1f4c7eabb0b8365b338adf3c",
+      "Hash": "716fde5382293cc94a71f68c85b78d19",
       "Requirements": [
         "bslib",
         "evaluate",

--- a/renv/.gitignore
+++ b/renv/.gitignore
@@ -1,3 +1,4 @@
+sandbox/
 library/
 local/
 cellar/

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,7 +2,7 @@
 local({
 
   # the requested version of renv
-  version <- "0.15.5"
+  version <- "0.16.0"
 
   # the project directory
   project <- getwd()
@@ -185,43 +185,80 @@ local({
     if (fixup)
       mode <- "w+b"
   
-    utils::download.file(
+    args <- list(
       url      = url,
       destfile = destfile,
       mode     = mode,
       quiet    = TRUE
     )
   
+    if ("headers" %in% names(formals(utils::download.file)))
+      args$headers <- renv_bootstrap_download_custom_headers(url)
+  
+    do.call(utils::download.file, args)
+  
+  }
+  
+  renv_bootstrap_download_custom_headers <- function(url) {
+  
+    headers <- getOption("renv.download.headers")
+    if (is.null(headers))
+      return(character())
+  
+    if (!is.function(headers))
+      stopf("'renv.download.headers' is not a function")
+  
+    headers <- headers(url)
+    if (length(headers) == 0L)
+      return(character())
+  
+    if (is.list(headers))
+      headers <- unlist(headers, recursive = FALSE, use.names = TRUE)
+  
+    ok <-
+      is.character(headers) &&
+      is.character(names(headers)) &&
+      all(nzchar(names(headers)))
+  
+    if (!ok)
+      stop("invocation of 'renv.download.headers' did not return a named character vector")
+  
+    headers
+  
   }
   
   renv_bootstrap_download_cran_latest <- function(version) {
   
     spec <- renv_bootstrap_download_cran_latest_find(version)
-  
-    message("* Downloading renv ", version, " ... ", appendLF = FALSE)
-  
     type  <- spec$type
     repos <- spec$repos
   
-    info <- tryCatch(
-      utils::download.packages(
-        pkgs    = "renv",
-        destdir = tempdir(),
-        repos   = repos,
-        type    = type,
-        quiet   = TRUE
-      ),
+    message("* Downloading renv ", version, " ... ", appendLF = FALSE)
+  
+    baseurl <- utils::contrib.url(repos = repos, type = type)
+    ext <- if (identical(type, "source"))
+      ".tar.gz"
+    else if (Sys.info()[["sysname"]] == "Windows")
+      ".zip"
+    else
+      ".tgz"
+    name <- sprintf("renv_%s%s", version, ext)
+    url <- paste(baseurl, name, sep = "/")
+  
+    destfile <- file.path(tempdir(), name)
+    status <- tryCatch(
+      renv_bootstrap_download_impl(url, destfile),
       condition = identity
     )
   
-    if (inherits(info, "condition")) {
+    if (inherits(status, "condition")) {
       message("FAILED")
       return(FALSE)
     }
   
     # report success and return
     message("OK (downloaded ", type, ")")
-    info[1, 2]
+    destfile
   
   }
   
@@ -678,7 +715,7 @@ local({
       return(profile)
   
     # check for a profile file (nothing to do if it doesn't exist)
-    path <- renv_bootstrap_paths_renv("profile", profile = FALSE)
+    path <- renv_bootstrap_paths_renv("profile", profile = FALSE, project = project)
     if (!file.exists(path))
       return(NULL)
   
@@ -805,9 +842,23 @@ local({
   
   renv_json_read <- function(file = NULL, text = NULL) {
   
+    # if jsonlite is loaded, use that instead
+    if ("jsonlite" %in% loadedNamespaces())
+      renv_json_read_jsonlite(file, text)
+    else
+      renv_json_read_default(file, text)
+  
+  }
+  
+  renv_json_read_jsonlite <- function(file = NULL, text = NULL) {
     text <- paste(text %||% read(file), collapse = "\n")
+    jsonlite::fromJSON(txt = text, simplifyVector = FALSE)
+  }
+  
+  renv_json_read_default <- function(file = NULL, text = NULL) {
   
     # find strings in the JSON
+    text <- paste(text %||% read(file), collapse = "\n")
     pattern <- '["](?:(?:\\\\.)|(?:[^"\\\\]))*?["]'
     locs <- gregexpr(pattern, text, perl = TRUE)[[1]]
   
@@ -838,8 +889,9 @@ local({
   
     # transform the JSON into something the R parser understands
     transformed <- replaced
-    transformed <- gsub("[[{]", "list(", transformed)
-    transformed <- gsub("[]}]", ")", transformed)
+    transformed <- gsub("{}", "`names<-`(list(), character())", transformed, fixed = TRUE)
+    transformed <- gsub("[[{]", "list(", transformed, perl = TRUE)
+    transformed <- gsub("[]}]", ")", transformed, perl = TRUE)
     transformed <- gsub(":", "=", transformed, fixed = TRUE)
     text <- paste(transformed, collapse = "\n")
   

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -55,7 +55,13 @@ test_that("All renv functions are called according to ci logic", {
   mockery::stub(ci, "lint_all", NULL)
   mockery::stub(ci, "gert::git_status", git_status_empty)
   mockery::stub(ci, "devtools::document", NULL)
+  mockery::stub(ci, "desc::desc_normalize", NULL)
   mockery::stub(ci, "rcmdcheck::rcmdcheck", NULL)
+  mockery::stub(ci, "print_tbl", NULL)
+  mockery::stub(ci, "missing_deps", NULL)
+  mockery::stub(ci, "extra_deps", NULL)
+  mockery::stub(ci, "url_check", NULL)
+  mockery::stub(ci, "html_url_check", NULL)
 
   begin <- "^"
   end <- "$"
@@ -64,46 +70,75 @@ test_that("All renv functions are called according to ci logic", {
   styler <- "style_all\\(\\)"
   lintr <- "lint_all\\(\\)"
   document <- "devtools::document\\(\\)"
+  normalize <- "desc::desc_normalize\\(\\)"
   rcmdcheck <- paste0(
     'Setting env vars: NOT_CRAN="true", CI="true"\\n',
     'rcmdcheck::rcmdcheck\\(args = "--no-manual", error_on = "warning"\\)'
   )
+  missing <- "missing_deps\\(\\)"
+  extra <- "extra_deps\\(\\)"
+  urls <- "url_check\\((\\))\nhtml_url_check\\(\\)"
 
   # default
   expect_output(
-    ci(), paste0(begin, renv, sep, styler, sep, lintr, sep, document, sep, rcmdcheck, end)
+    ci(),
+    paste0(
+      begin, renv, sep, styler, sep, lintr, sep, document, sep, normalize, sep, rcmdcheck, sep,
+      missing, sep, extra, sep, urls, end
+    )
   )
 
   # all
   expect_output(
-    ci(renv = TRUE, styler = TRUE, lintr = TRUE, document = TRUE, rcmdcheck = TRUE),
-    paste0(begin, renv, sep, styler, sep, lintr, sep, document, sep, rcmdcheck, end)
+    ci(
+      renv = TRUE, styler = TRUE, lintr = TRUE, document = TRUE, normalize = TRUE, rcmdcheck = TRUE,
+      missing = TRUE, extra = TRUE, urls = TRUE
+    ),
+    paste0(
+      begin, renv, sep, styler, sep, lintr, sep, document, sep, normalize, sep, rcmdcheck, sep,
+      missing, sep, extra, sep, urls, end
+    )
   )
 
   # none
   expect_output(
-    ci(renv = FALSE, styler = FALSE, lintr = FALSE, document = FALSE, rcmdcheck = FALSE), NA
+    ci(
+      renv = FALSE, styler = FALSE, lintr = FALSE, document = FALSE, normalize = FALSE,
+      rcmdcheck = FALSE, missing = FALSE, extra = FALSE, urls = FALSE
+    ), NA
   )
 
   # uncommitted changes
   mockery::stub(ci, "gert::git_status", git_status_changed)
   expect_output(
-    ci(renv = TRUE, styler = NULL, lintr = TRUE, document = TRUE, rcmdcheck = TRUE),
-    paste0(begin, renv, sep, lintr, sep, document, sep, rcmdcheck, end)
+    ci(
+      renv = TRUE, styler = NULL, lintr = TRUE, document = TRUE, normalize = TRUE, rcmdcheck = TRUE,
+      missing = TRUE, extra = TRUE, urls = TRUE
+    ),
+    paste0(
+      begin, renv, sep, lintr, sep, document, sep, normalize, sep, rcmdcheck, sep, missing, sep,
+      extra, sep, urls, end
+    )
   )
 
   # lints found
   mockery::stub(ci, "gert::git_status", git_status_empty)
   mockery::stub(ci, "lint_all", list("lint"))
   expect_output(
-    ci(renv = TRUE, styler = NULL, lintr = TRUE, document = TRUE, rcmdcheck = TRUE),
+    ci(
+      renv = TRUE, styler = NULL, lintr = TRUE, document = TRUE, normalize = TRUE, rcmdcheck = TRUE,
+      missing = TRUE, extra = TRUE, urls = TRUE
+    ),
     paste0(begin, renv, sep, styler, sep, lintr, end)
   )
 
   # renv not synchronized
   mockery::stub(ci, "renv::status", renv_sync_false)
   expect_output(
-    ci(renv = TRUE, styler = NULL, lintr = TRUE, document = TRUE, rcmdcheck = TRUE),
+    ci(
+      renv = TRUE, styler = NULL, lintr = TRUE, document = TRUE, normalize = TRUE, rcmdcheck = TRUE,
+      missing = TRUE, extra = TRUE, urls = TRUE
+    ),
     paste0(begin, renv, end)
   )
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -84,6 +84,13 @@ test_that("deps_check finds correct missing and extra deps", {
     "/Users/test/pkg/tests/test.R", "desc_source_2", "", "", FALSE,
     "/Users/test/pkg/R/function_1.R", "source_only_1", "", "", FALSE,
     "/Users/test/pkg/tests/test.R", "source_only_2", "", "", FALSE,
+    # base packages loaded at startup
+    "/Users/test/pkg/R/function_1.R", "base", "", "", FALSE,
+    "/Users/test/pkg/tests/test.R", "utils", "", "", FALSE,
+    # base packages loaded later
+    "/Users/test/pkg/R/function_1.R", "grDevices", "", "", FALSE,
+    "/Users/test/pkg/tests/test.R", "stats", "", "", FALSE,
+    # always ignore pkg and renv
     "/Users/test/pkg/renv.lock", "renv", "", "", FALSE,
     "/Users/test/pkg/tests/test.R", "pkg", "", "", FALSE
   ))
@@ -117,6 +124,22 @@ test_that("deps_check finds correct missing and extra deps", {
     row.names = 7:8,
     class = "data.frame"
   )
+
+  missing_withbase <- structure(
+    list(
+      Source = c(
+        "/Users/test/pkg/R/function_1.R", "/Users/test/pkg/tests/test.R",
+        "/Users/test/pkg/R/function_1.R", "/Users/test/pkg/tests/test.R",
+        "/Users/test/pkg/R/function_1.R", "/Users/test/pkg/tests/test.R"
+      ),
+      Package = c("source_only_1", "source_only_2", "base", "utils", "grDevices", "stats"),
+      Require = c("", "", "", "", "", ""),
+      Version = c("", "", "", "", "", ""),
+      Dev = c(FALSE, FALSE, FALSE, FALSE, FALSE, FALSE)
+    ),
+    row.names = 7:12,
+    class = "data.frame"
+  )
   # nolint end
 
   mockery::stub(deps_check, "renv::dependencies", renv_dependencies)
@@ -129,10 +152,12 @@ test_that("deps_check finds correct missing and extra deps", {
   mockery::stub(deps_check, "writeLines", NULL)
   expect_identical(deps_check("extra"), extras)
   expect_identical(deps_check("missing"), missing)
+  expect_identical(deps_check("missing", exclude_base = TRUE), missing)
+  expect_identical(deps_check("missing", exclude_base = FALSE), missing_withbase)
 })
 
 test_that("missing_deps and extra_deps call correct deps_check type", {
-  dc <- function(type) {
+  dc <- function(type, exclude_base = TRUE) {
     type
   }
   mockery::stub(missing_deps, "deps_check", dc)


### PR DESCRIPTION
* `missing_deps()` now excludes base R packages by default

* Added new checks to `ci()`: `missing_deps()`, `desc::desc_normalize()`, `extra_deps()`, `url_check()`, and `html_url_check()`; `ci()` will stop if `missing_deps()` returns one or more rows

* Added `missing-deps.yaml` GitHub Action